### PR TITLE
refac: Remove  “All Listings” Tab from /dashboard/listings

### DIFF
--- a/apps/web/components/marketplace/ListingsTabs.tsx
+++ b/apps/web/components/marketplace/ListingsTabs.tsx
@@ -1,8 +1,8 @@
-'use client';
+"use client";
 
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import type { MarketplaceListing } from '@/lib/types/marketplace';
-import { ListingCard } from './ListingCard';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import type { MarketplaceListing } from "@/lib/types/marketplace";
+import { ListingCard } from "./ListingCard";
 
 interface ListingsTabsProps {
   listings: MarketplaceListing[];
@@ -10,18 +10,12 @@ interface ListingsTabsProps {
 }
 
 export function ListingsTabs({ listings, onTrade }: ListingsTabsProps) {
-  const buyListings = listings.filter((l) => l.type === 'buy');
-  const sellListings = listings.filter((l) => l.type === 'sell');
+  const buyListings = listings.filter((l) => l.type === "buy");
+  const sellListings = listings.filter((l) => l.type === "sell");
 
   return (
-    <Tabs defaultValue="all" className="space-y-6">
+    <Tabs defaultValue="buy" className="space-y-6">
       <TabsList className="glass-card bg-white/80 backdrop-blur-sm border border-white/30 p-1 flex flex-col gap-2 sm:flex-row sm:flex-wrap">
-        <TabsTrigger
-          value="all"
-          className="data-[state=active]:bg-emerald-500 data-[state=active]:text-white data-[state=active]:shadow-lg transition-all duration-300 w-full sm:w-auto"
-        >
-          All Listings ({listings.length})
-        </TabsTrigger>
         <TabsTrigger
           value="buy"
           className="data-[state=active]:bg-emerald-500 data-[state=active]:text-white data-[state=active]:shadow-lg transition-all duration-300 w-full sm:w-auto"
@@ -35,14 +29,6 @@ export function ListingsTabs({ listings, onTrade }: ListingsTabsProps) {
           Sell Orders ({sellListings.length})
         </TabsTrigger>
       </TabsList>
-
-      <TabsContent value="all" className="space-y-6">
-        <div className="grid gap-6">
-          {listings.map((listing) => (
-            <ListingCard key={listing.id} listing={listing} onTrade={onTrade} />
-          ))}
-        </div>
-      </TabsContent>
 
       <TabsContent value="buy" className="space-y-6">
         <div className="grid gap-6">

--- a/package-lock.json
+++ b/package-lock.json
@@ -3405,6 +3405,7 @@
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -13016,6 +13017,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }


### PR DESCRIPTION
Have remove the All Listings" tab from the marketplace listings page.

close #26 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed "All Listings" tab from the marketplace interface.
  * Updated the default marketplace view to the "Buy" tab.
  * Simplified tab navigation to display only "Buy" and "Sell" tabs, each showing filtered listing counts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->