### PR TITLE
refactor:  remove TrendingUp icon from History tab empty state in Das…

### DIFF
--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -288,9 +288,6 @@ export default function DashboardPage() {
           </h2>
           <Card className="card">
             <CardContent className="p-8 sm:p-12 lg:p-16 text-center">
-              <div className="w-12 h-12 sm:w-16 sm:h-16 bg-muted/50 backdrop-blur-sm rounded-2xl flex items-center justify-center mx-auto mb-4 glow-emerald">
-                <TrendingUp className="w-6 h-6 sm:w-8 sm:h-8 text-muted-foreground" />
-              </div>
               <p className="text-base sm:text-lg text-muted-foreground mb-2 font-medium">
                 No completed trades yet
               </p>


### PR DESCRIPTION
The TrendingUp icon was removed from the history tab

closes https://github.com/PACTO-LAT/pacto-p2p/issues/50
<img width="922" height="398" alt="Captura de pantalla 2026-02-24 a la(s) 8 15 11 p  m" src="https://github.com/user-attachments/assets/26dca968-ffa3-4969-aec5-d5c820eca6f0" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed a decorative icon element from the Trade History card on the dashboard, resulting in a cleaner, more streamlined interface. All core information and functionality remain intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->