### PR TITLE
fix: Edit Profile database integration

### DIFF
--- a/apps/web/app/dashboard/profile/page.tsx
+++ b/apps/web/app/dashboard/profile/page.tsx
@@ -346,6 +346,12 @@ export default function EnhancedProfilePage() {
             >
               Notifications
             </TabsTrigger>
+            <TabsTrigger
+              value="security"
+              className="bg-card/60 hover:bg-card/80 active:bg-card/90 text-muted-foreground hover:text-foreground data-[state=active]:bg-emerald-500 data-[state=active]:text-white data-[state=active]:shadow-md data-[state=active]:border-emerald-600 transition-all duration-200 rounded-md px-4 py-3 sm:py-2.5 text-sm font-medium border border-transparent cursor-pointer w-full sm:w-auto sm:flex-initial whitespace-nowrap justify-center min-h-[44px] sm:min-h-0"
+            >
+              Security
+            </TabsTrigger>
           </TabsList>
 
           {/* Profile Tab */}

--- a/apps/web/lib/schemas/profile-validation.schema.ts
+++ b/apps/web/lib/schemas/profile-validation.schema.ts
@@ -70,7 +70,8 @@ export const profileUpdateSchema = z.object({
         .string()
         .min(2, 'Full name must be at least 2 characters')
         .max(255, 'Full name is too long')
-        .optional(),
+        .optional()
+        .or(z.literal('')),
 
     username: z
         .string()
@@ -80,7 +81,8 @@ export const profileUpdateSchema = z.object({
             usernameRegex,
             'Username can only contain letters, numbers, hyphens, and underscores'
         )
-        .optional(),
+        .optional()
+        .or(z.literal('')),
 
     email: z
         .string()


### PR DESCRIPTION
## Summary

Fixes #32 - Connect "Edit Profile" button on /profile to update personal information in the database.

## Changes

- **Security tab**: Added missing TabsTrigger for the Security tab. The TabsContent existed but was inaccessible to users.
- **Profile validation schema**: Allow empty strings for `full_name` and `username` fields so users can clear these optional fields.

## Context

The profile page already had robust database integration in place:
- Zod schema validation
- EnhancedAuthService with unique constraint checks
- Error handling and loading states
- Success/error toasts
- JSONB fields (notifications, security, payment_methods) support

This PR completes the remaining gaps: the Security tab was unreachable and the validation schema rejected empty strings for optional fields.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Security tab to the profile dashboard alongside existing profile options.

* **Bug Fixes**
  * Improved form validation to properly handle empty submissions for name and username fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->