### PR TITLE
feat: receipt upload to Supabase Storage

### DIFF
--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -2,6 +2,7 @@
 
 import { AlertCircle, Plus } from 'lucide-react';
 import { Card, CardContent } from '@/components/ui/card';
+import type { Escrow } from '@pacto-p2p/types';
 import type { DashboardEscrow, DashboardListing } from '@/lib/types';
 import { DisputeDialog, ReceiptDialog } from '@/components/shared/DashboardDialogs';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -15,6 +16,9 @@ import { TradeCard } from '@/components/shared/TradeCard';
 import { WalletConnectionPrompt } from '@/components/shared/WalletConnectionPrompt';
 import { useAuth } from '@/hooks/use-auth';
 import { useDialog } from '@/hooks/use-dialog';
+import { useInitializeTrade } from '@/hooks/use-trades';
+import { uploadReceipt } from '@/lib/services/receipts';
+import { sileo } from 'sileo';
 import useGlobalAuthenticationStore from '@/store/wallet.store';
 import { useMarketplaceListings } from '@/hooks/use-listings';
 import { useTrades } from '@/hooks/use-trades-history';
@@ -37,6 +41,8 @@ export default function DashboardPage() {
     setSelectedItem: setEditListing,
   } = useDialog<DashboardListing>();
 
+  const { reportPayment } = useInitializeTrade();
+  const [isUploadingReceipt, setIsUploadingReceipt] = useState(false);
   const { data: merchant, isLoading: merchantLoading } = useMeMerchant();
   const {
     data: trades = [],
@@ -93,9 +99,36 @@ export default function DashboardPage() {
     }
   };
 
-  const handleUploadReceipt = (escrow: DashboardEscrow, file: File) => {
-    console.log('Uploading receipt for escrow:', escrow.id, file);
-    closeDialog();
+  const handleUploadReceipt = async (
+    escrow: DashboardEscrow,
+    file: File
+  ): Promise<void> => {
+    if (!escrow.contractId || !escrow.roles?.serviceProvider) {
+      sileo.error({
+        title: 'Cannot report payment',
+        description:
+          'This escrow is missing contract data. Ensure you are viewing an active escrow from Trustless Work.',
+      });
+      return;
+    }
+
+    setIsUploadingReceipt(true);
+    try {
+      const receiptUrl = await uploadReceipt(escrow.id, file);
+      const escrowForReport: Pick<Escrow, 'contractId' | 'roles'> = {
+        contractId: escrow.contractId,
+        roles: { serviceProvider: escrow.roles.serviceProvider },
+      };
+      await reportPayment(escrowForReport as Escrow, receiptUrl);
+      sileo.success({ title: 'Payment receipt uploaded successfully' });
+      closeDialog();
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : 'Failed to upload receipt. Please try again.';
+      sileo.error({ title: 'Upload failed', description: message });
+    } finally {
+      setIsUploadingReceipt(false);
+    }
   };
 
   const handleCreateDispute = (escrow: DashboardEscrow, reason: string) => {
@@ -340,6 +373,7 @@ export default function DashboardPage() {
         onOpenChange={closeDialog}
         escrow={dialogState.selectedItem}
         onUpload={handleUploadReceipt}
+        isUploading={isUploadingReceipt}
       />
 
       <DisputeDialog

--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -2,7 +2,6 @@
 
 import { AlertCircle, Plus } from 'lucide-react';
 import { Card, CardContent } from '@/components/ui/card';
-import type { Escrow } from '@pacto-p2p/types';
 import type { DashboardEscrow, DashboardListing } from '@/lib/types';
 import { DisputeDialog, ReceiptDialog } from '@/components/shared/DashboardDialogs';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -115,11 +114,13 @@ export default function DashboardPage() {
     setIsUploadingReceipt(true);
     try {
       const receiptUrl = await uploadReceipt(escrow.id, file);
-      const escrowForReport: Pick<Escrow, 'contractId' | 'roles'> = {
-        contractId: escrow.contractId,
-        roles: { serviceProvider: escrow.roles.serviceProvider },
-      };
-      await reportPayment(escrowForReport as Escrow, receiptUrl);
+      await reportPayment(
+        {
+          contractId: escrow.contractId,
+          roles: { serviceProvider: escrow.roles.serviceProvider },
+        },
+        receiptUrl
+      );
       sileo.success({ title: 'Payment receipt uploaded successfully' });
       closeDialog();
     } catch (err) {

--- a/apps/web/components/shared/DashboardDialogs.tsx
+++ b/apps/web/components/shared/DashboardDialogs.tsx
@@ -18,7 +18,8 @@ interface ReceiptDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   escrow: DashboardEscrow | null;
-  onUpload: (escrow: DashboardEscrow, file: File) => void;
+  onUpload: (escrow: DashboardEscrow, file: File) => Promise<void>;
+  isUploading?: boolean;
 }
 
 interface DisputeDialogProps {
@@ -33,6 +34,7 @@ export function ReceiptDialog({
   onOpenChange,
   escrow,
   onUpload,
+  isUploading = false,
 }: ReceiptDialogProps) {
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
 
@@ -43,10 +45,11 @@ export function ReceiptDialog({
     }
   };
 
-  const handleUpload = () => {
+  const handleUpload = async () => {
     if (escrow && selectedFile) {
-      onUpload(escrow, selectedFile);
+      await onUpload(escrow, selectedFile);
       setSelectedFile(null);
+      handleClose();
     }
   };
 
@@ -85,10 +88,10 @@ export function ReceiptDialog({
           )}
           <Button
             onClick={handleUpload}
-            disabled={!selectedFile}
+            disabled={!selectedFile || isUploading}
             className="w-full btn-emerald"
           >
-            Upload Receipt
+            {isUploading ? 'Uploading...' : 'Upload Receipt'}
           </Button>
         </div>
       </DialogContent>

--- a/apps/web/hooks/use-trades.ts
+++ b/apps/web/hooks/use-trades.ts
@@ -115,7 +115,10 @@ export const useInitializeTrade = () => {
     }
   };
 
-  const reportPayment = async (escrow: Escrow, evidence: string) => {
+  const reportPayment = async (
+    escrow: Escrow | { contractId: string; roles: { serviceProvider: string } },
+    evidence: string
+  ) => {
     if (!address) {
       throw new Error('Wallet address is required. Please connect your wallet.');
     }

--- a/apps/web/lib/services/receipts.ts
+++ b/apps/web/lib/services/receipts.ts
@@ -1,0 +1,37 @@
+import { supabase } from '@/lib/supabase';
+
+const RECEIPTS_BUCKET = 'receipts';
+const MAX_FILE_SIZE_MB = 10;
+const ACCEPTED_TYPES = [
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+  'application/pdf',
+];
+
+export async function uploadReceipt(
+  escrowId: string,
+  file: File
+): Promise<string> {
+  if (file.size > MAX_FILE_SIZE_MB * 1024 * 1024) {
+    throw new Error(`File too large. Maximum size is ${MAX_FILE_SIZE_MB}MB.`);
+  }
+
+  if (!ACCEPTED_TYPES.includes(file.type)) {
+    throw new Error(
+      'Invalid file type. Use JPEG, PNG, WebP, or PDF.'
+    );
+  }
+
+  const ext = file.name.split('.').pop() || 'bin';
+  const path = `${escrowId}/${Date.now()}_${crypto.randomUUID()}.${ext}`;
+
+  const { error } = await supabase.storage
+    .from(RECEIPTS_BUCKET)
+    .upload(path, file, { upsert: false });
+
+  if (error) throw error;
+
+  const { data } = supabase.storage.from(RECEIPTS_BUCKET).getPublicUrl(path);
+  return data.publicUrl;
+}

--- a/apps/web/lib/types.ts
+++ b/apps/web/lib/types.ts
@@ -115,6 +115,9 @@ export interface DashboardEscrow {
   status: string;
   progress: number;
   created: string;
+  /** Required for reportPayment - from Trustless Work Escrow */
+  contractId?: string;
+  roles?: { serviceProvider?: string };
 }
 
 export interface MarketplaceListing {

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -54,6 +54,11 @@ public = true
 file_size_limit = "5MiB"
 allowed_mime_types = ["image/jpeg", "image/png", "image/webp"]
 
+[storage.buckets.receipts]
+public = true
+file_size_limit = "10MiB"
+allowed_mime_types = ["image/jpeg", "image/png", "image/webp", "application/pdf"]
+
 [realtime]
 enabled = true
 

--- a/supabase/migrations/20260305000000_create_receipts_bucket.sql
+++ b/supabase/migrations/20260305000000_create_receipts_bucket.sql
@@ -1,0 +1,39 @@
+-- Create receipts bucket for trade payment evidence (images, PDFs)
+-- Path structure: {escrow_id}/{timestamp}_{filename}
+-- Public read for receipt URLs passed as TLW milestone evidence
+
+DO $$
+BEGIN
+  INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+  VALUES (
+    'receipts',
+    'receipts',
+    true,
+    10485760,
+    ARRAY['image/jpeg', 'image/png', 'image/webp', 'application/pdf']::text[]
+  )
+  ON CONFLICT (id) DO NOTHING;
+EXCEPTION
+  WHEN undefined_table THEN NULL;
+END $$;
+
+DROP POLICY IF EXISTS "Users can upload receipts" ON storage.objects;
+CREATE POLICY "Users can upload receipts"
+ON storage.objects FOR INSERT TO authenticated
+WITH CHECK (bucket_id = 'receipts');
+
+DROP POLICY IF EXISTS "Receipts are publicly accessible" ON storage.objects;
+CREATE POLICY "Receipts are publicly accessible"
+ON storage.objects FOR SELECT TO public
+USING (bucket_id = 'receipts');
+
+DROP POLICY IF EXISTS "Users can update receipts" ON storage.objects;
+CREATE POLICY "Users can update receipts"
+ON storage.objects FOR UPDATE TO authenticated
+USING (bucket_id = 'receipts')
+WITH CHECK (bucket_id = 'receipts');
+
+DROP POLICY IF EXISTS "Users can delete receipts" ON storage.objects;
+CREATE POLICY "Users can delete receipts"
+ON storage.objects FOR DELETE TO authenticated
+USING (bucket_id = 'receipts');


### PR DESCRIPTION
## Changes

- Receipts bucket in Supabase Storage with RLS migration and policies
- UploadReceipt service to upload receipts to receipts/{escrow_id}/{timestamp}_{uuid}.{ext}
- ReceiptDialog with async upload, isUploading status, and closure after successful upload
- Dashboard: HandleUploadReceipt uploads the file, obtains the public URL, and calls reportPayment with the URL as proof
- Type fix: reportPayment now accepts minimal objects with contractId and roles.serviceProvider

- [x] Closes #68 

## Modified Files

- supabase/migrations/20260305000000_create_receipts_bucket.sql – bucket and policies
- supabase/config.toml – bucket receipts config
- `apps/web/lib/services/receipts.ts` – upload service
- `apps/web/lib/types.ts` – type `DashboardEscrow`
- `apps/web/components/shared/DashboardDialogs.tsx` – ReceiptDialog with onUpload
- `apps/web/app/dashboard/page.tsx` – handleUploadReceipt
- `apps/web/hooks/use-trades.ts` – reportPayment signature

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Receipt upload functionality now available, supporting common image formats (JPEG, PNG, WebP) and PDF files.
  * File uploads are validated with a 10 MB size limit to ensure efficient storage.
  * Real-time upload progress indicator displays in the dashboard dialog, providing users with clear feedback during file uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->