### PR TITLE
fix: client-side validation that only the seller can call fundEscrow

### DIFF
--- a/apps/web/hooks/use-escrows.ts
+++ b/apps/web/hooks/use-escrows.ts
@@ -270,7 +270,7 @@ export function useDepositFunds() {
   return useMutation({
     mutationFn: ({ escrow }: { escrow: Escrow }) => {
       if (!address) {
-        throw new Error('Wallet address is required. Please connect your wallet.');
+        throw new Error('Wallet not connected');
       }
 
       if (!escrow.contractId) {
@@ -279,6 +279,10 @@ export function useDepositFunds() {
 
       if (!escrow.amount || escrow.amount <= 0) {
         throw new Error('Invalid escrow amount.');
+      }
+
+      if (address !== escrow.roles.releaseSigner) {
+        throw new Error('Only the seller can deposit funds into this escrow');
       }
 
       return fundEscrow(
@@ -302,12 +306,24 @@ export function useDepositFunds() {
 
 export function useDisputeEscrow() {
   const { disputeEscrow } = useInitializeTrade();
+  const { address } = useGlobalAuthenticationStore();
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: ({ escrow }: { escrow: Escrow }) => {
+      if (!address) {
+        throw new Error('Wallet not connected');
+      }
+
       if (!escrow.contractId) {
         throw new Error('Escrow contract ID is required.');
+      }
+
+      const isParticipant =
+        address === escrow.roles.releaseSigner ||
+        address === escrow.roles.serviceProvider;
+      if (!isParticipant) {
+        throw new Error('Only escrow participants can raise a dispute');
       }
 
       return disputeEscrow(escrow);


### PR DESCRIPTION
This PR closes #75 

## Summary
Added explicit signer/participant authorization checks in escrow mutation hooks to prevent invalid wallet actions before triggering TLW transactions.

## Changes
- Updated [`useDepositFunds`](/home/uche-ofatu/Desktop/pacto-p2p/apps/web/hooks/use-escrows.ts) to:
  - throw if wallet is not connected
  - throw if connected address is not `escrow.roles.releaseSigner` (seller)
- Updated [`useDisputeEscrow`](/home/uche-ofatu/Desktop/pacto-p2p/apps/web/hooks/use-escrows.ts) to:
  - throw if wallet is not connected
  - throw unless connected address is one of escrow participants (`releaseSigner` or `serviceProvider`)
- Kept existing `onError` toast handling unchanged, so guard failures are shown clearly to users.

## Why
UI-level tab gating is not sufficient as a security/UX boundary. These hook-level guards prevent avoidable signing prompts and confusing on-chain rejections when an unauthorized wallet attempts escrow actions.

## Acceptance Criteria Coverage
- `useDepositFunds` now rejects non-seller addresses with a clear error.
- `useDisputeEscrow` now enforces participant-only disputes.
- Errors are surfaced via existing toast `onError` handlers.
- Happy path remains unchanged for authorized users.