### PR TITLE
Fix/prevent self trade

### DIFF
--- a/apps/web/app/dashboard/listings/page.tsx
+++ b/apps/web/app/dashboard/listings/page.tsx
@@ -144,6 +144,11 @@ export default function ListingsPage() {
       ? currentUserAddress
       : listingCreatorAddress;
 
+    if (seller_id === buyer_id) {
+      sileo.error({ title: 'You cannot trade against your own listing' });
+      return;
+    }
+
     mutate({
       listing: {
         ...selectedListing,

--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -58,6 +58,7 @@ export default function DashboardPage() {
   // Escrow modal state
   const [isEscrowModalOpen, setIsEscrowModalOpen] = useState(false);
   const [isReportPaymentModalOpen, setIsReportPaymentModalOpen] = useState(false);
+  const [isUploadingReceipt, setIsUploadingReceipt] = useState(false);
   const { selectedEscrow, selectEscrow, clearSelectedEscrow } = useEscrowSelection();
   const {
     isReportPaymentLoading,
@@ -67,6 +68,7 @@ export default function DashboardPage() {
     handleDisputeEscrow,
     handleReleaseFunds,
   } = useEscrowActions();
+  const { reportPayment } = useInitializeTrade();
 
   const { data: merchant, isLoading: merchantLoading } = useMeMerchant();
   const {

--- a/apps/web/components/marketplace/ListingCard.tsx
+++ b/apps/web/components/marketplace/ListingCard.tsx
@@ -9,6 +9,8 @@ import { TokenIcon } from '@/components/shared/TokenIcon';
 import { TradeTypeBadge } from '@/components/shared/TradeTypeBadge';
 import { formatAmount, formatDate } from '@/lib/dashboard-utils';
 import { MarketplaceListing } from '@/lib/types/marketplace';
+import useGlobalAuthenticationStore from '@/store/wallet.store';
+import { useAuth } from '@/hooks/use-auth';
 
 interface ListingCardProps {
   listing: MarketplaceListing;
@@ -16,6 +18,14 @@ interface ListingCardProps {
 }
 
 export function ListingCard({ listing, onTrade }: ListingCardProps) {
+  const { address } = useGlobalAuthenticationStore();
+  const { user } = useAuth();
+  const isOwnListing =
+    listing.seller === address ||
+    listing.seller === user?.id ||
+    listing.buyer === address ||
+    listing.buyer === user?.id;
+
   return (
     <Card className="card hover:shadow-2xl hover:scale-[1.02] transition-all duration-300 animate-fade-in">
       <CardContent className="p-0">
@@ -115,9 +125,11 @@ export function ListingCard({ listing, onTrade }: ListingCardProps) {
 
               <Button
                 onClick={() => onTrade(listing)}
+                disabled={isOwnListing}
+                title={isOwnListing ? 'This is your listing' : ''}
                 className="btn-emerald w-full justify-center px-8 py-2 text-base font-semibold sm:w-auto"
               >
-                {listing.type === 'sell' ? 'Buy Now' : 'Sell Now'}
+                {isOwnListing ? 'Your Listing' : listing.type === 'sell' ? 'Buy Now' : 'Sell Now'}
               </Button>
             </div>
           </div>

--- a/apps/web/components/merchant/CreateListingModal.tsx
+++ b/apps/web/components/merchant/CreateListingModal.tsx
@@ -173,6 +173,7 @@ export function CreateListingModal({
     return (
       <Dialog open={open} onOpenChange={handleOpenChange}>
         <DialogContent>
+          <DialogTitle className="sr-only">Loading</DialogTitle>
           <div className="flex items-center justify-center py-12">
             <span className="text-gray-500">Checking merchant status...</span>
           </div>
@@ -185,6 +186,7 @@ export function CreateListingModal({
     return (
       <Dialog open={open} onOpenChange={handleOpenChange}>
         <DialogContent>
+          <DialogTitle className="sr-only">Merchant Required</DialogTitle>
           <div className="flex flex-col items-center justify-center py-12">
             <p className="mb-4 text-center text-lg text-gray-700">
               You need a merchant profile to create a listing.
@@ -206,13 +208,12 @@ export function CreateListingModal({
       <Dialog open={open} onOpenChange={handleOpenChange}>
         <DialogContent
           className="fixed inset-0 w-full max-h-[100dvh] rounded-none border-0 sm:inset-auto sm:top-[50%] sm:left-[50%] sm:translate-x-[-50%] sm:translate-y-[-50%] sm:max-w-lg sm:max-h-[90vh] sm:rounded-lg sm:border sm:p-6 gap-4 overflow-y-auto"
-          aria-describedby={undefined}
         >
           <DialogHeader>
-            <DialogTitle id="create-listing-modal-title">
+            <DialogTitle>
               Create Listing
             </DialogTitle>
-            <DialogDescription id="create-listing-modal-description">
+            <DialogDescription>
               Complete the steps below to create your OTC trade listing.
             </DialogDescription>
           </DialogHeader>
@@ -275,11 +276,10 @@ export function CreateListingModal({
       <Dialog open={showDiscardConfirm} onOpenChange={setShowDiscardConfirm}>
         <DialogContent
           className="sm:max-w-md"
-          aria-describedby="discard-confirm-description"
         >
           <DialogHeader>
             <DialogTitle>Discard changes?</DialogTitle>
-            <DialogDescription id="discard-confirm-description">
+            <DialogDescription>
               You have unsaved changes. Are you sure you want to close? Your
               progress will be lost.
             </DialogDescription>

--- a/apps/web/components/merchant/MerchantProfileForm.tsx
+++ b/apps/web/components/merchant/MerchantProfileForm.tsx
@@ -31,7 +31,7 @@ import {
 } from '@/components/ui/select';
 import { Label } from '@/components/ui/label';
 import { supabase } from '@/lib/supabase';
-import { useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { X } from 'lucide-react';
 import Image from 'next/image';
 import { countries as countriesData } from 'countries-list';
@@ -96,11 +96,25 @@ export function MerchantProfileForm({
 
   const upsert = useUpsertMerchantProfile();
 
+  // Reset mutation state if it gets stuck (e.g. due to network timeout)
+  const resetIfStuck = useCallback(() => {
+    if (upsert.isPending) {
+      upsert.reset();
+    }
+  }, [upsert]);
+
+  useEffect(() => {
+    if (!upsert.isPending) return;
+    const timeout = setTimeout(resetIfStuck, 30_000); // 30s safety timeout
+    return () => clearTimeout(timeout);
+  }, [upsert.isPending, resetIfStuck]);
+
   async function onSubmit(values: FormValues) {
     if (!isConnected) {
       sileo.error({ title: 'Connect your wallet to save your merchant profile' });
       return;
     }
+
     const payload = {
       display_name: values.display_name,
       bio: values.bio?.trim() || undefined,

--- a/apps/web/components/merchant/MerchantProfileForm.tsx
+++ b/apps/web/components/merchant/MerchantProfileForm.tsx
@@ -121,8 +121,15 @@ export function MerchantProfileForm({
       is_public: values.is_public,
       slug: values.slug || undefined,
     };
-    await upsert.mutateAsync(payload);
-    sileo.success({ title: 'Profile saved' });
+    try {
+      await upsert.mutateAsync(payload);
+      sileo.success({ title: 'Profile saved' });
+    } catch (err) {
+      sileo.error({
+        title: 'Failed to save profile',
+        description: err instanceof Error ? err.message : 'Unknown error',
+      });
+    }
   }
 
   return (

--- a/apps/web/components/merchant/steps/TradeTypeStep.tsx
+++ b/apps/web/components/merchant/steps/TradeTypeStep.tsx
@@ -66,7 +66,7 @@ export function TradeTypeStep() {
                   </SelectTrigger>
                   <SelectContent>
                     {TRUSTLINES.map((t) => (
-                      <SelectItem key={t.address} value={t.name}>
+                      <SelectItem key={t.symbol} value={t.name}>
                         {t.name}
                       </SelectItem>
                     ))}

--- a/apps/web/lib/adapters/merchant.supabase.ts
+++ b/apps/web/lib/adapters/merchant.supabase.ts
@@ -71,9 +71,11 @@ function slugify(input: string): string {
 
 async function ensureUniqueSlug(base: string): Promise<string> {
   let candidate = slugify(base);
+  if (!candidate) candidate = 'merchant';
   let suffix = 1;
+  const MAX_ATTEMPTS = 20;
   // Try the base, then append -1,-2,... until unique
-  while (true) {
+  while (suffix <= MAX_ATTEMPTS) {
     const { data, error } = await supabase
       .from('merchants')
       .select('id')
@@ -82,7 +84,43 @@ async function ensureUniqueSlug(base: string): Promise<string> {
       .maybeSingle();
     if (error) throw new Error(error.message);
     if (!data) return candidate;
-    candidate = `${slugify(base)}-${suffix++}`;
+    candidate = `${slugify(base) || 'merchant'}-${suffix++}`;
+  }
+  // Fallback: use a random suffix
+  return `${slugify(base) || 'merchant'}-${Date.now().toString(36)}`;
+}
+
+/**
+ * Ensure the user profile exists in the public.users table.
+ * The handle_new_user trigger should create it on signup, but it may not
+ * have fired (e.g. user was created before the trigger was added).
+ */
+async function ensureUserProfile(userId: string): Promise<void> {
+  const { data } = await supabase
+    .from('users')
+    .select('id')
+    .eq('id', userId)
+    .maybeSingle();
+
+  if (data) return; // Profile exists
+
+  // Get email from the current session
+  const { data: { session } } = await supabase.auth.getSession();
+  const email = session?.user?.email ?? `${userId}@auth.local`;
+
+  const { error } = await supabase
+    .from('users')
+    .insert({
+      id: userId,
+      email,
+      reputation_score: 0,
+      total_trades: 0,
+      total_volume: 0,
+    });
+
+  // 23505 = unique constraint violation → profile already exists (race condition)
+  if (error && error.code !== '23505') {
+    throw new Error(error.message || 'Failed to create user profile');
   }
 }
 
@@ -216,13 +254,24 @@ export const merchantSupabaseAdapter: MerchantAdapter = {
 
   async upsertMyMerchantProfile(input) {
     const userId = await resolveCurrentUserId();
-    if (!userId) throw new Error('Not authenticated');
+    if (!userId) throw new Error('Not authenticated — please sign in with email before saving your merchant profile');
 
-    const { data: existing } = await supabase
+    // Ensure user profile exists in the users table (trigger may not have fired)
+    await ensureUserProfile(userId);
+
+    const { data: existing, error: existingError } = await supabase
       .from('merchants')
       .select('*')
       .eq('user_id', userId)
       .maybeSingle();
+
+    if (existingError) {
+      console.error('Error checking existing merchant:', existingError);
+      // PGRST116 = 0 rows with .single(), safe to ignore for maybeSingle
+      if (existingError.code !== 'PGRST116') {
+        throw new Error(existingError.message || 'Failed to check existing merchant profile');
+      }
+    }
 
     const desiredSlug = input.slug || input.display_name;
     const finalSlug = existing?.slug
@@ -343,8 +392,10 @@ export const merchantSupabaseAdapter: MerchantAdapter = {
 
 async function resolveCurrentUserId(): Promise<string | null> {
   try {
-    const { data: auth } = await supabase.auth.getUser();
-    return auth.user?.id ?? null;
+    // Use getSession() instead of getUser() — reads from localStorage instantly.
+    // getUser() makes a network call that can hang if the auth server is slow.
+    const { data: { session } } = await supabase.auth.getSession();
+    return session?.user?.id ?? null;
   } catch {
     return null;
   }

--- a/apps/web/lib/adapters/merchant.supabase.ts
+++ b/apps/web/lib/adapters/merchant.supabase.ts
@@ -80,7 +80,7 @@ async function ensureUniqueSlug(base: string): Promise<string> {
       .eq('slug', candidate)
       .limit(1)
       .maybeSingle();
-    if (error) throw error;
+    if (error) throw new Error(error.message);
     if (!data) return candidate;
     candidate = `${slugify(base)}-${suffix++}`;
   }
@@ -93,7 +93,7 @@ export const merchantSupabaseAdapter: MerchantAdapter = {
       .select('*')
       .eq('is_public', true)
       .order('created_at', { ascending: false });
-    if (error) throw error;
+    if (error) throw new Error(error.message);
     return (data ?? []).map(mapRowToMerchant);
   },
 
@@ -113,7 +113,7 @@ export const merchantSupabaseAdapter: MerchantAdapter = {
       if (e.code === 'PGRST116') return null;
       if (e.details?.includes('Results contain 0')) return null;
       if (e.message?.includes('No rows')) return null;
-      throw error;
+      throw new Error(error.message);
     }
     return data ? mapRowToMerchant(data) : null;
   },
@@ -124,7 +124,7 @@ export const merchantSupabaseAdapter: MerchantAdapter = {
       .from('listings')
       .select('id', { count: 'exact', head: true })
       .eq('merchant_id', merchantId);
-    if (error) throw error;
+    if (error) throw new Error(error.message);
     const badges: MerchantBadge[] = [];
     if ((count ?? 0) >= 1) {
       badges.push({
@@ -145,7 +145,7 @@ export const merchantSupabaseAdapter: MerchantAdapter = {
       .from('listings')
       .select('id', { count: 'exact', head: true })
       .eq('merchant_id', merchantId);
-    if (error) throw error;
+    if (error) throw new Error(error.message);
     return {
       total_trades: total ?? 0,
       completed_trades: 0,
@@ -174,7 +174,7 @@ export const merchantSupabaseAdapter: MerchantAdapter = {
       .eq('merchant_id', merchantId)
       .eq('status', 'active')
       .order('created_at', { ascending: false });
-    if (error) throw error;
+    if (error) throw new Error(error.message);
     const rows = data ?? [];
     return rows.map((r) => ({
       id: r.id,
@@ -209,7 +209,7 @@ export const merchantSupabaseAdapter: MerchantAdapter = {
       if (e.code === 'PGRST116') return null;
       if (e.details?.includes('Results contain 0')) return null;
       if (e.message?.includes('No rows')) return null;
-      throw error;
+      throw new Error(error.message);
     }
     return data ? mapRowToMerchant(data) : null;
   },
@@ -253,7 +253,7 @@ export const merchantSupabaseAdapter: MerchantAdapter = {
         .eq('id', existing.id)
         .select('*')
         .single();
-      if (error) throw error;
+      if (error) throw new Error(error.message || 'Failed to update merchant profile');
       return mapRowToMerchant(data);
     }
 
@@ -262,7 +262,7 @@ export const merchantSupabaseAdapter: MerchantAdapter = {
       .insert(payload)
       .select('*')
       .single();
-    if (error) throw error;
+    if (error) throw new Error(error.message || 'Failed to create merchant profile');
     return mapRowToMerchant(data);
   },
 
@@ -295,7 +295,7 @@ export const merchantSupabaseAdapter: MerchantAdapter = {
       .insert(insert)
       .select('*')
       .single();
-    if (error) throw error;
+    if (error) throw new Error(error.message);
 
     return {
       id: data.id,
@@ -322,7 +322,7 @@ export const merchantSupabaseAdapter: MerchantAdapter = {
       .select('*')
       .eq('user_id', userId)
       .order('created_at', { ascending: false });
-    if (error) throw error;
+    if (error) throw new Error(error.message);
 
     return (data ?? []).map((r) => ({
       id: r.id,

--- a/apps/web/lib/services/auth.ts
+++ b/apps/web/lib/services/auth.ts
@@ -96,7 +96,7 @@ export class AuthService {
 
     if (error) {
       if (error.code === 'PGRST116') return null; // No rows returned
-      throw error;
+      throw new Error(error.message);
     }
 
     return normalizeUserFromDb(data as Record<string, unknown>);
@@ -118,7 +118,7 @@ export class AuthService {
       if (e.code === 'PGRST116') return null;
       if (e.message?.includes('No rows found')) return null;
       if (e.details?.includes('Results contain 0')) return null;
-      throw error;
+      throw new Error(error.message);
     }
     return normalizeUserFromDb(data as Record<string, unknown>) ?? null;
   }
@@ -137,7 +137,7 @@ export class AuthService {
       .select()
       .single();
 
-    if (error) throw error;
+    if (error) throw new Error(error.message);
     return normalizeUserFromDb(data as Record<string, unknown>) ?? (data as User);
   }
 
@@ -179,7 +179,7 @@ export class AuthService {
           userId,
           email,
         });
-        throw error;
+        throw new Error(error.message);
       }
     } catch (err) {
       // Enhanced error logging
@@ -192,7 +192,7 @@ export class AuthService {
         email,
       };
       console.error('Profile creation failed:', errorDetails);
-      throw err;
+      throw err instanceof Error ? err : new Error(String(err));
     }
   }
 }

--- a/apps/web/lib/services/listings.ts
+++ b/apps/web/lib/services/listings.ts
@@ -30,7 +30,7 @@ export class ListingsService {
 
     const { data, error } = await query;
 
-    if (error) throw error;
+    if (error) throw new Error(error.message);
     return (data as unknown as DbListing[]) || [];
   }
 
@@ -46,7 +46,7 @@ export class ListingsService {
       .eq('user_id', userId)
       .order('created_at', { ascending: false });
 
-    if (error) throw error;
+    if (error) throw new Error(error.message);
     return (data as unknown as DbListing[]) || [];
   }
 
@@ -88,7 +88,7 @@ export class ListingsService {
       )
       .single();
 
-    if (error) throw error;
+    if (error) throw new Error(error.message);
     return data as unknown as DbListing;
   }
 
@@ -111,7 +111,7 @@ export class ListingsService {
       )
       .single();
 
-    if (error) throw error;
+    if (error) throw new Error(error.message);
     return data as unknown as DbListing;
   }
 
@@ -121,7 +121,7 @@ export class ListingsService {
       .delete()
       .eq('id', listingId);
 
-    if (error) throw error;
+    if (error) throw new Error(error.message);
   }
 
   static async getListingById (listingId: string): Promise<DbListing | null> {
@@ -138,7 +138,7 @@ export class ListingsService {
 
     if (error) {
       if (error.code === 'PGRST116') return null;
-      throw error;
+      throw new Error(error.message);
     }
 
     return (data as unknown as DbListing) ?? null;

--- a/apps/web/lib/services/trades.ts
+++ b/apps/web/lib/services/trades.ts
@@ -44,7 +44,7 @@ export class TradesService {
       .or(`buyer_id.eq.${userId},seller_id.eq.${userId}`)
       .order('created_at', { ascending: false });
 
-    if (error) throw error;
+    if (error) throw new Error(error.message);
 
     const trades = (data as DbTrade[]) ?? [];
     return trades.map((t) => mapTradeToDashboardListing(t, userId));

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -56,6 +56,7 @@
     "recharts": "^2.12.7",
     "resend": "^4.8.0",
     "sileo": "^0.1.5",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.3.1",
     "tailwindcss-animate": "^1.0.7",
     "zod": "^4.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "lucide-react": "^0.525.0",
         "motion": "^12.23.26",
         "next": "^16.1.6",
+        "next-themes": "^0.4.6",
         "ogl": "^1.0.11",
         "react": "^19.2.1",
         "react-dom": "^19.2.1",
@@ -65,6 +66,7 @@
         "recharts": "^2.12.7",
         "resend": "^4.8.0",
         "sileo": "^0.1.5",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.3.1",
         "tailwindcss-animate": "^1.0.7",
         "zod": "^4.0.5",
@@ -10447,21 +10449,6 @@
         }
       }
     },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -12032,6 +12019,16 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/next/node_modules/@img/sharp-darwin-arm64": {
@@ -14093,6 +14090,16 @@
       "license": "MIT",
       "dependencies": {
         "atomic-sleep": "^1.0.0"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map-js": {


### PR DESCRIPTION
## Prevent self-trading & improve merchant/marketplace robustness

closes #73 

### Summary

This PR fixes a critical issue where users could trade against their own listings, deploying a single-release escrow with both parties being the same address. It also introduces several improvements to error handling, merchant profile flows, and accessibility.

---

### 🚨 Self-trade prevention (main fix)

A user could click "Trade" on a listing they created themselves. `confirmTrade` resolved both the listing creator's and current user's Stellar addresses but never compared them — resulting in a self-escrow where `approver === serviceProvider`, wasting gas fees and producing a nonsensical trade.

**Changes:**
- Added a guard in `confirmTrade` that returns early with an error toast when `seller_id === buyer_id` (`apps/web/app/dashboard/listings/page.tsx`)
- The Trade button in `ListingCard` is now **disabled** for the listing owner, displays a "Your Listing" label, and shows a tooltip explaining why (`apps/web/components/marketplace/ListingCard.tsx`)

---

### Merchant profile & database robustness

- All Supabase operations in `merchant.supabase.ts` and `auth.ts` now throw descriptive `Error` objects instead of raw errors, improving debuggability
- Added `ensureUserProfile()` to guarantee user rows exist in `public.users` before merchant upsert, handling cases where the `handle_new_user` trigger hasn't fired
- Improved slug generation: fallback to `"merchant"` when the base is empty, caps retry attempts at 20, and falls back to a timestamp-based suffix

### Merchant profile form

- Added a 30-second safety timeout to reset stuck mutation state, preventing the form from hanging on network issues
- Switched from `useMemo` to `useCallback` + `useEffect` for more predictable mutation state management
- Improved error handling on profile save

### Accessibility & UI

- Added semantic `DialogTitle` elements to modal dialogs; removed unnecessary `aria-describedby` attributes
- Fixed `SelectItem` key in `TradeTypeStep` to use `symbol` instead of `address`, preventing React key collisions

### Minor

- `resolveCurrentUserId()` now uses `getSession()` instead of `getUser()`, avoiding a blocking network call and improving responsiveness

---

### Files changed

| File | Change |
|---|---|
| `apps/web/app/dashboard/listings/page.tsx` | Self-trade guard in `confirmTrade` |
| `apps/web/components/marketplace/ListingCard.tsx` | Disable Trade button for own listings |
| `apps/web/lib/adapters/merchant.supabase.ts` | Descriptive errors, `ensureUserProfile`, slug improvements |
| `apps/web/lib/services/auth.ts` | Descriptive error objects |
| `apps/web/components/merchant/*` | Form timeout, mutation state fixes |
| `apps/web/components/marketplace/TradeTypeStep.tsx` | Fix `SelectItem` key |
| Various dialog components | Accessible `DialogTitle` elements |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents users from trading against their own listings with appropriate error messaging
  * Enhanced error handling and automatic recovery for merchant profile updates with timeout protection

* **New Features**
  * Added receipt upload progress tracking in the dashboard

* **Accessibility**
  * Improved screen reader support and ARIA accessibility in modal dialogs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->