### PR TITLE
fix: persist escrow to Supabase after on-chain creation

### DIFF
--- a/apps/web/hooks/use-escrows.ts
+++ b/apps/web/hooks/use-escrows.ts
@@ -12,6 +12,7 @@ import {
 import { useRouter } from 'next/navigation';
 import { sileo } from 'sileo';
 import type { CreateEscrowData } from '@/lib/types';
+import { supabase } from '@/lib/supabase';
 import useGlobalAuthenticationStore from '@/store/wallet.store';
 import { useInitializeTrade } from './use-trades';
 
@@ -219,7 +220,48 @@ export function useCreateEscrow(onSuccessCallback?: () => void) {
         throw new Error('Token is required.');
       }
 
-      return initializeTrade(escrowData);
+      const { engagementId, contractId, listingId } =
+        await initializeTrade(escrowData);
+
+      // 1. Insert into escrows table
+      const { data: escrowRow, error: escrowError } = await supabase
+        .from('escrows')
+        .insert({
+          listing_id: listingId,
+          buyer_id: escrowData.buyer_id,
+          seller_id: escrowData.seller_id,
+          engagement_id: engagementId,
+          fiat_amount: escrowData.fiat_amount,
+        })
+        .select()
+        .single();
+
+      if (escrowError) {
+        console.error('Failed to persist escrow to Supabase:', escrowError);
+        throw new Error(`Failed to save escrow: ${escrowError.message}`);
+      }
+
+      // 2. Insert into trades table
+      const { error: tradeError } = await supabase.from('trades').insert({
+        escrow_id: escrowRow.id,
+        listing_id: listingId,
+        buyer_id: escrowData.buyer_id,
+        seller_id: escrowData.seller_id,
+        token: escrowData.token || escrowData.listing.token,
+        token_amount: escrowData.amount,
+        fiat_amount: escrowData.fiat_amount,
+        fiat_currency: escrowData.fiat_currency || escrowData.listing.fiat_currency,
+        rate: escrowData.listing.rate,
+        payment_method: escrowData.listing.payment_method,
+        status: 'active',
+      });
+
+      if (tradeError) {
+        console.error('Failed to persist trade to Supabase:', tradeError);
+        // Note: Escrow is already created on-chain and in Supabase escrows table.
+      }
+
+      return { engagementId, contractId, listingId };
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['escrows'] });

--- a/apps/web/hooks/use-escrows.ts
+++ b/apps/web/hooks/use-escrows.ts
@@ -223,14 +223,38 @@ export function useCreateEscrow(onSuccessCallback?: () => void) {
       const { engagementId, contractId, listingId } =
         await initializeTrade(escrowData);
 
+      // Resolve Stellar addresses to Supabase user UUIDs.
+      // escrowData.buyer_id / seller_id are Stellar public keys (G...),
+      // but the escrows and trades tables FK-reference users(id) which are UUIDs.
+      const [{ data: buyerUser }, { data: sellerUser }] = await Promise.all([
+        supabase
+          .from('users')
+          .select('id')
+          .eq('stellar_address', escrowData.buyer_id)
+          .single(),
+        supabase
+          .from('users')
+          .select('id')
+          .eq('stellar_address', escrowData.seller_id)
+          .single(),
+      ]);
+
+      if (!buyerUser) {
+        throw new Error('Buyer account not found. The wallet address is not registered on this platform.');
+      }
+      if (!sellerUser) {
+        throw new Error('Seller account not found. The wallet address is not registered on this platform.');
+      }
+
       // 1. Insert into escrows table
       const { data: escrowRow, error: escrowError } = await supabase
         .from('escrows')
         .insert({
           listing_id: listingId,
-          buyer_id: escrowData.buyer_id,
-          seller_id: escrowData.seller_id,
+          buyer_id: buyerUser.id,
+          seller_id: sellerUser.id,
           engagement_id: engagementId,
+          contract_id: contractId,
           fiat_amount: escrowData.fiat_amount,
         })
         .select()
@@ -245,8 +269,8 @@ export function useCreateEscrow(onSuccessCallback?: () => void) {
       const { error: tradeError } = await supabase.from('trades').insert({
         escrow_id: escrowRow.id,
         listing_id: listingId,
-        buyer_id: escrowData.buyer_id,
-        seller_id: escrowData.seller_id,
+        buyer_id: buyerUser.id,
+        seller_id: sellerUser.id,
         token: escrowData.token || escrowData.listing.token,
         token_amount: escrowData.amount,
         fiat_amount: escrowData.fiat_amount,
@@ -258,7 +282,7 @@ export function useCreateEscrow(onSuccessCallback?: () => void) {
 
       if (tradeError) {
         console.error('Failed to persist trade to Supabase:', tradeError);
-        // Note: Escrow is already created on-chain and in Supabase escrows table.
+        throw new Error(`Failed to save trade: ${tradeError.message}`);
       }
 
       return { engagementId, contractId, listingId };

--- a/apps/web/hooks/use-trades.ts
+++ b/apps/web/hooks/use-trades.ts
@@ -96,7 +96,7 @@ export const useInitializeTrade = () => {
       ],
     };
 
-    const { unsignedTransaction } = await deployEscrow(
+    const { unsignedTransaction, contractId } = await deployEscrow(
       finalPayload,
       'single-release'
     );
@@ -121,6 +121,8 @@ export const useInitializeTrade = () => {
     if (response.status !== 'SUCCESS') {
       throw new Error('Transaction failed to send');
     }
+
+    return { engagementId, contractId, listingId };
   };
 
   const reportPayment = async (

--- a/apps/web/lib/adapters/merchant.supabase.ts
+++ b/apps/web/lib/adapters/merchant.supabase.ts
@@ -178,19 +178,59 @@ export const merchantSupabaseAdapter: MerchantAdapter = {
   },
 
   async getKpis(merchantId: string): Promise<MerchantKpis> {
-    // Compute from listings table as a proxy (until trades/escrows table is wired)
+    const { data: merchant } = await supabase
+      .from('merchants')
+      .select('user_id')
+      .eq('id', merchantId)
+      .single();
+
+    if (!merchant) throw new Error('Merchant not found');
+
     const { count: total, error } = await supabase
-      .from('listings')
+      .from('trades')
       .select('id', { count: 'exact', head: true })
-      .eq('merchant_id', merchantId);
+      .or(`seller_id.eq.${merchant.user_id},buyer_id.eq.${merchant.user_id}`);
+
     if (error) throw new Error(error.message);
+
+    const { count: completed } = await supabase
+      .from('trades')
+      .select('id', { count: 'exact', head: true })
+      .eq('status', 'completed')
+      .or(`seller_id.eq.${merchant.user_id},buyer_id.eq.${merchant.user_id}`);
+
+    const { count: disputed } = await supabase
+      .from('trades')
+      .select('id', { count: 'exact', head: true })
+      .eq('status', 'disputed')
+      .or(`seller_id.eq.${merchant.user_id},buyer_id.eq.${merchant.user_id}`);
+
+    const thirtyDaysAgo = new Date();
+    thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+
+    const { data: volumeData } = await supabase
+      .from('trades')
+      .select('fiat_amount')
+      .eq('status', 'completed')
+      .or(`seller_id.eq.${merchant.user_id},buyer_id.eq.${merchant.user_id}`)
+      .gte('created_at', thirtyDaysAgo.toISOString());
+
+    const volume30d =
+      volumeData?.reduce(
+        (acc: number, curr: { fiat_amount: string | number }) =>
+          acc + Number(curr.fiat_amount),
+        0
+      ) ?? 0;
+
     return {
       total_trades: total ?? 0,
-      completed_trades: 0,
-      disputed_trades: 0,
-      completion_rate_pct: 0,
-      dispute_rate_pct: 0,
-      volume_30d: 0,
+      completed_trades: completed ?? 0,
+      disputed_trades: disputed ?? 0,
+      completion_rate_pct: total
+        ? Math.round(((completed ?? 0) / total) * 100)
+        : 0,
+      dispute_rate_pct: total ? Math.round(((disputed ?? 0) / total) * 100) : 0,
+      volume_30d: volume30d,
       median_release_minutes: null,
     };
   },
@@ -214,7 +254,19 @@ export const merchantSupabaseAdapter: MerchantAdapter = {
       .order('created_at', { ascending: false });
     if (error) throw new Error(error.message);
     const rows = data ?? [];
-    return rows.map((r) => ({
+    return rows.map((r: {
+      id: string;
+      type: string;
+      token: string;
+      rate: string | number;
+      fiat_currency: string;
+      amount: string | number;
+      min_amount: string | number | null;
+      max_amount: string | number | null;
+      description: string | null;
+      status: string;
+      created_at: string;
+    }) => ({
       id: r.id,
       side: r.type,
       asset_code: r.token,
@@ -389,7 +441,19 @@ export const merchantSupabaseAdapter: MerchantAdapter = {
       .order('created_at', { ascending: false });
     if (error) throw new Error(error.message);
 
-    return (data ?? []).map((r) => ({
+    return (data ?? []).map((r: {
+      id: string;
+      type: string;
+      token: string;
+      rate: string | number;
+      fiat_currency: string;
+      amount: string | number;
+      min_amount: string | number | null;
+      max_amount: string | number | null;
+      description: string | null;
+      status: string;
+      created_at: string;
+    }) => ({
       id: r.id,
       side: r.type,
       asset_code: r.token,

--- a/supabase/migrations/20260328000000_add_contract_id_to_escrows.sql
+++ b/supabase/migrations/20260328000000_add_contract_id_to_escrows.sql
@@ -1,0 +1,6 @@
+-- Add contract_id to escrows table to store the on-chain Soroban contract identifier.
+-- This is required to make subsequent TrustlessWork API calls (fund, dispute, release)
+-- that can be linked back to a Supabase record.
+ALTER TABLE escrows ADD COLUMN IF NOT EXISTS contract_id TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_escrows_contract_id ON escrows(contract_id);


### PR DESCRIPTION
Description:
Updated 

initializeTrade
 hook to return engagementId, contractId, and listingId.
Modified 

useCreateEscrow
 to perform sequential insertions into Supabase escrows and trades tables upon successful on-chain transaction.
Refactored 

getKpis
 in 

merchant.supabase.ts
 to fetch real metrics (total trades, completed trades, disputed trades, and 30d volume) from the trades table.
Fixed several TypeScript linting issues in 

merchant.supabase.ts
 to ensure type safety.
Why it was done:

The escrow creation flow was deploying the contract on-chain but failing to persist the record in Supabase, leading to empty escrows and trades tables.
This fix enables Merchant KPIs, trade history tracking, and other platform features that depend on database records.
How it was verified:

Logic was verified against the database schema defined in migrations and documentation.
Type integrity was checked to ensure compliance with existing project patterns.
Error handling was added to the database insertion flow to prevent silent failures.
Closes #102

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added 30-day trading volume metric to merchant analytics.

* **Improvements**
  * Merchant KPIs now derive from actual trade data with more accurate completion and dispute rates.
  * Escrow and trade persistence strengthened for improved reliability and data synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->