### PR TITLE
feat: add trade notifications system with pending action badge

### DIFF
--- a/apps/web/app/dashboard/layout.tsx
+++ b/apps/web/app/dashboard/layout.tsx
@@ -2,6 +2,7 @@
 
 import dynamic from 'next/dynamic';
 import type React from 'react';
+import { TradeNotificationsProvider } from '@/providers/trade-notifications.provider';
 
 // Load header only on client to avoid Radix UI hydration mismatch (auto-generated IDs differ between SSR and client)
 const DashboardHeader = dynamic(
@@ -18,13 +19,15 @@ export default function DashboardLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="min-h-screen flex flex-col">
-      <div className="h-16 shrink-0">
-        <DashboardHeader />
+    <TradeNotificationsProvider>
+      <div className="min-h-screen flex flex-col">
+        <div className="h-16 shrink-0">
+          <DashboardHeader />
+        </div>
+        <main className="flex-1 p-4 pt-12 sm:p-5 sm:pt-14 md:p-6 md:pt-16 lg:p-8 lg:pt-20 max-w-full overflow-x-hidden">
+          {children}
+        </main>
       </div>
-      <main className="flex-1 p-4 pt-12 sm:p-5 sm:pt-14 md:p-6 md:pt-16 lg:p-8 lg:pt-20 max-w-full overflow-x-hidden">
-        {children}
-      </main>
-    </div>
+    </TradeNotificationsProvider>
   );
 }

--- a/apps/web/components/layout/dashboard-header.tsx
+++ b/apps/web/components/layout/dashboard-header.tsx
@@ -21,6 +21,7 @@ import {
 import { useState, useEffect } from 'react';
 
 import { Button } from '@/components/ui/button';
+import { usePendingActions } from '@/hooks/use-pending-actions';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -48,6 +49,7 @@ export function DashboardHeader() {
   const pathname = usePathname();
   const { handleDisconnect, handleConnect } = useWallet();
   const { address, isConnected } = useGlobalAuthenticationStore();
+  const { pendingCount } = usePendingActions();
   const { user, signOut, updateProfile, loading: authLoading } = useAuth();
   const canSeeAdmin = process.env.NEXT_PUBLIC_ENABLE_ADMIN === 'true';
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
@@ -170,9 +172,11 @@ export function DashboardHeader() {
   const NavLink = ({
     item,
     onClick,
+    badge,
   }: {
     item: (typeof navigation)[number];
     onClick?: () => void;
+    badge?: number;
   }) => (
     <Link
       href={item.href}
@@ -187,6 +191,11 @@ export function DashboardHeader() {
     >
       <item.icon className="w-4 h-4" />
       <span>{item.name}</span>
+      {badge ? (
+        <span className="ml-1 flex h-5 min-w-5 items-center justify-center rounded-full bg-red-500 px-1 text-[10px] font-bold text-white">
+          {badge > 9 ? '9+' : badge}
+        </span>
+      ) : null}
     </Link>
   );
 
@@ -211,7 +220,11 @@ export function DashboardHeader() {
           {/* Desktop Navigation */}
           <nav className="hidden md:flex items-center gap-1">
             {navigation.map((item) => (
-              <NavLink key={item.name} item={item} />
+              <NavLink
+                key={item.name}
+                item={item}
+                badge={item.href === '/dashboard/orders' && pendingCount > 0 ? pendingCount : undefined}
+              />
             ))}
             {canSeeAdmin && (
               <Link
@@ -435,6 +448,7 @@ export function DashboardHeader() {
                         key={item.name}
                         item={item}
                         onClick={() => setMobileMenuOpen(false)}
+                        badge={item.href === '/dashboard/orders' && pendingCount > 0 ? pendingCount : undefined}
                       />
                     ))}
                     {canSeeAdmin && (

--- a/apps/web/hooks/use-pending-actions.ts
+++ b/apps/web/hooks/use-pending-actions.ts
@@ -1,0 +1,79 @@
+'use client';
+
+import type { Escrow } from '@pacto-p2p/types';
+import { useEscrowsByRoleQuery } from './use-escrows';
+import useGlobalAuthenticationStore from '@/store/wallet.store';
+
+export function usePendingActions() {
+  const { address } = useGlobalAuthenticationStore();
+
+  const sellerParams = {
+    role: 'approver' as const,
+    roleAddress: address ?? '',
+    isActive: true,
+    enabled: !!address,
+  };
+
+  const buyerParams = {
+    role: 'serviceProvider' as const,
+    roleAddress: address ?? '',
+    isActive: true,
+    enabled: !!address,
+  };
+
+  const { data: sellerEscrows = [] } = useEscrowsByRoleQuery(sellerParams);
+  const { data: buyerEscrows = [] } = useEscrowsByRoleQuery(buyerParams);
+
+  const pendingCount = countPendingActions(sellerEscrows, buyerEscrows);
+
+  return { pendingCount };
+}
+
+function countPendingActions(
+  sellerEscrows: Escrow[],
+  buyerEscrows: Escrow[]
+): number {
+  let count = 0;
+
+  for (const escrow of sellerEscrows) {
+    const milestone = escrow.milestones[0];
+    const flags = escrow.flags;
+
+    if (flags?.released || flags?.resolved) continue;
+
+    // Seller needs to deposit when balance is 0
+    if ((escrow.balance ?? 0) === 0) {
+      count++;
+      continue;
+    }
+
+    // Seller needs to confirm payment when buyer has reported
+    if (milestone?.status === 'pendingApproval') {
+      count++;
+      continue;
+    }
+
+    // Seller needs to release funds when payment is approved
+    if (milestone?.approved && (escrow.balance ?? 0) !== 0) {
+      count++;
+    }
+  }
+
+  for (const escrow of buyerEscrows) {
+    const milestone = escrow.milestones[0];
+    const flags = escrow.flags;
+
+    if (flags?.released || flags?.resolved) continue;
+
+    // Buyer needs to report payment when escrow is funded and not yet reported
+    if (
+      (escrow.balance ?? 0) > 0 &&
+      milestone?.status !== 'pendingApproval' &&
+      !milestone?.approved
+    ) {
+      count++;
+    }
+  }
+
+  return count;
+}

--- a/apps/web/providers/trade-notifications.provider.tsx
+++ b/apps/web/providers/trade-notifications.provider.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { sileo } from 'sileo';
+import { supabase } from '@/lib/supabase';
+import useGlobalAuthenticationStore from '@/store/wallet.store';
+
+const TRADE_STATUS_MESSAGES: Record<string, string> = {
+  initialized: 'A new escrow has been created',
+  funded: 'Escrow has been funded — send your payment and report it',
+  paymentReported: 'Payment reported — confirm or dispute',
+  completed: 'Trade completed successfully',
+  disputed: 'A dispute has been raised on this trade',
+  resolved: 'Trade dispute has been resolved',
+};
+
+export function TradeNotificationsProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const queryClient = useQueryClient();
+  const { address } = useGlobalAuthenticationStore();
+
+  useEffect(() => {
+    if (!address) return;
+
+    const channel = supabase
+      .channel('trade-notifications')
+      .on(
+        'postgres_changes',
+        {
+          event: '*',
+          schema: 'public',
+          table: 'trades',
+          filter: `buyer_id=eq.${address}`,
+        },
+        (payload) => {
+          queryClient.invalidateQueries({ queryKey: ['escrows'] });
+
+          const newStatus = (payload.new as { status?: string })?.status;
+          if (newStatus && TRADE_STATUS_MESSAGES[newStatus]) {
+            sileo.info({ title: TRADE_STATUS_MESSAGES[newStatus] });
+          }
+        }
+      )
+      .on(
+        'postgres_changes',
+        {
+          event: '*',
+          schema: 'public',
+          table: 'trades',
+          filter: `seller_id=eq.${address}`,
+        },
+        (payload) => {
+          queryClient.invalidateQueries({ queryKey: ['escrows'] });
+
+          const newStatus = (payload.new as { status?: string })?.status;
+          if (newStatus && TRADE_STATUS_MESSAGES[newStatus]) {
+            sileo.info({ title: TRADE_STATUS_MESSAGES[newStatus] });
+          }
+        }
+      )
+      .subscribe();
+
+    return () => {
+      supabase.removeChannel(channel);
+    };
+  }, [address, queryClient]);
+
+  return <>{children}</>;
+}

--- a/apps/web/providers/trade-notifications.provider.tsx
+++ b/apps/web/providers/trade-notifications.provider.tsx
@@ -4,12 +4,13 @@ import { useEffect } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { sileo } from 'sileo';
 import { supabase } from '@/lib/supabase';
-import useGlobalAuthenticationStore from '@/store/wallet.store';
+import { useAuth } from '@/hooks/use-auth';
 
+// Matches actual trades.status values written to Supabase.
+// On-chain TrustlessWork states (funded, paymentReported, etc.) are not
+// persisted to trades.status — those transitions happen on-chain only.
 const TRADE_STATUS_MESSAGES: Record<string, string> = {
-  initialized: 'A new escrow has been created',
-  funded: 'Escrow has been funded — send your payment and report it',
-  paymentReported: 'Payment reported — confirm or dispute',
+  active: 'A new trade has been initiated',
   completed: 'Trade completed successfully',
   disputed: 'A dispute has been raised on this trade',
   resolved: 'Trade dispute has been resolved',
@@ -21,20 +22,21 @@ export function TradeNotificationsProvider({
   children: React.ReactNode;
 }) {
   const queryClient = useQueryClient();
-  const { address } = useGlobalAuthenticationStore();
+  const { user } = useAuth();
 
   useEffect(() => {
-    if (!address) return;
+    if (!user?.id) return;
 
+    // Channel name is unique per user to avoid collisions on re-renders
     const channel = supabase
-      .channel('trade-notifications')
+      .channel(`trade-notifications-${user.id}`)
       .on(
         'postgres_changes',
         {
           event: '*',
           schema: 'public',
           table: 'trades',
-          filter: `buyer_id=eq.${address}`,
+          filter: `buyer_id=eq.${user.id}`,
         },
         (payload) => {
           queryClient.invalidateQueries({ queryKey: ['escrows'] });
@@ -51,7 +53,7 @@ export function TradeNotificationsProvider({
           event: '*',
           schema: 'public',
           table: 'trades',
-          filter: `seller_id=eq.${address}`,
+          filter: `seller_id=eq.${user.id}`,
         },
         (payload) => {
           queryClient.invalidateQueries({ queryKey: ['escrows'] });
@@ -67,7 +69,7 @@ export function TradeNotificationsProvider({
     return () => {
       supabase.removeChannel(channel);
     };
-  }, [address, queryClient]);
+  }, [user?.id, queryClient]);
 
   return <>{children}</>;
 }


### PR DESCRIPTION
Implements real-time trade lifecycle notifications and a pending action badge on the Orders nav link.

Changes:

TradeNotificationsProvider — subscribes to Supabase Realtime trades table, invalidates escrow cache, and shows sileo toasts on status changes
usePendingActions — computes pending action count from active buyer/seller escrows
Dashboard layout wrapped with TradeNotificationsProvider
Orders nav link shows a badge with pending action count (desktop + mobile)
Closes #109

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a pending actions badge on the Orders navigation link, showing counts of orders needing attention (displays "9+" when over 9).
  * Enabled real-time trade notifications across the dashboard to alert you of important order status changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->