### PR TITLE
fix(#113): validate Stellar trustlines before escrow funding

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -67,6 +67,9 @@ NEXT_PUBLIC_ENV=development
 # Mock mode: set to 1 to bypass real blockchain/API calls during development
 NEXT_PUBLIC_USE_MOCK=0
 
+# Stellar Network: set to "mainnet" or "testnet" for Horizon API calls
+NEXT_PUBLIC_STELLAR_NETWORK=testnet
+
 # Supported assets shown on the landing page.
 # JSON object keyed by asset symbol. Each value must have: name, region, paymentMethods, color.
 # If unset or invalid, the app falls back to default assets (CRCX, MXNX, USDC).

--- a/apps/web/components/escrow/EscrowDetailsModal.tsx
+++ b/apps/web/components/escrow/EscrowDetailsModal.tsx
@@ -23,6 +23,8 @@ import { TradesService } from '@/lib/services/trades';
 import { getTrustlineName } from '@/utils/getTrustline';
 import { Escrow } from '@/lib/types/escrow';
 import { EscrowTransactionHashesDisplay } from './TransactionHashDisplay';
+import { TrustlineError } from '@/utils/stellar/TrustlineError';
+import { TrustlineBanner } from '@/components/shared/TrustlineBanner';
 
 interface EscrowDetailsModalProps {
   open: boolean;
@@ -49,6 +51,9 @@ export function EscrowDetailsModal({
 }: EscrowDetailsModalProps) {
   const [transactionHashes, setTransactionHashes] =
     useState<EscrowTransactionHashes | null>(null);
+  const [trustlineError, setTrustlineError] = useState<TrustlineError | null>(
+    null
+  );
 
   useEffect(() => {
     if (open && escrow?.engagementId) {
@@ -197,6 +202,12 @@ export function EscrowDetailsModal({
               Available Actions
             </h4>
 
+            {/* Trustline error banner — shown when depositFunds/releaseFunds
+                detects a missing trustline before hitting the blockchain */}
+            {trustlineError && (
+              <TrustlineBanner error={trustlineError} />
+            )}
+
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
               {activeTab === 'buyer' &&
                 escrow.milestones[0].status !== 'pendingApproval' &&
@@ -229,7 +240,16 @@ export function EscrowDetailsModal({
                     !escrow.flags?.released &&
                     !escrow.flags?.resolved && (
                       <Button
-                        onClick={() => onDeposit(escrow)}
+                        onClick={async () => {
+                          setTrustlineError(null);
+                          try {
+                            await onDeposit(escrow);
+                          } catch (err) {
+                            if (err instanceof TrustlineError) {
+                              setTrustlineError(err);
+                            }
+                          }
+                        }}
                         className="w-full btn-emerald-outline"
                         variant="outline"
                       >
@@ -240,7 +260,16 @@ export function EscrowDetailsModal({
 
                   {escrow.milestones[0].approved && escrow.balance !== 0 && (
                     <Button
-                      onClick={() => onReleaseFunds(escrow)}
+                      onClick={async () => {
+                        setTrustlineError(null);
+                        try {
+                          await onReleaseFunds(escrow);
+                        } catch (err) {
+                          if (err instanceof TrustlineError) {
+                            setTrustlineError(err);
+                          }
+                        }
+                      }}
                       className="w-full btn-emerald-outline"
                       variant="outline"
                     >

--- a/apps/web/components/shared/TrustlineBanner.tsx
+++ b/apps/web/components/shared/TrustlineBanner.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { AlertTriangle, ExternalLink, Info } from 'lucide-react';
+import type { TrustlineError } from '@/utils/stellar/TrustlineError';
+
+interface TrustlineBannerProps {
+  error: TrustlineError;
+}
+
+export function TrustlineBanner({ error }: TrustlineBannerProps) {
+  const isBuyer = error.role === 'buyer';
+  const docsUrl =
+    'https://docs.trustlesswork.com/trustless-work/introduction/stellar-and-soroban-the-backbone-of-trustless-work/trustlines';
+
+  return (
+    <div className="rounded-lg border border-amber-500/50 bg-amber-500/10 p-4 space-y-3">
+      {/* Title row */}
+      <div className="flex items-center gap-2">
+        <AlertTriangle className="h-4 w-4 shrink-0 text-amber-400" />
+        <p className="font-semibold text-amber-300 text-sm">
+          Missing Trustline — {error.assetCode}
+        </p>
+      </div>
+
+      {/* Description */}
+      <p className="text-amber-100/90 text-sm leading-relaxed">
+        {isBuyer ? (
+          <>
+            Your wallet does not have a{' '}
+            <span className="font-semibold">{error.assetCode}</span> trustline.
+            You must add it before this trade can proceed.
+          </>
+        ) : (
+          <>
+            The seller&apos;s wallet does not have a{' '}
+            <span className="font-semibold">{error.assetCode}</span> trustline.
+            They must set it up before this escrow can be funded.
+          </>
+        )}
+      </p>
+
+      {/* Step-by-step guide for the buyer */}
+      {isBuyer && (
+        <div className="space-y-1.5">
+          <p className="text-amber-200/80 text-xs font-medium uppercase tracking-wide flex items-center gap-1">
+            <Info className="h-3 w-3" /> How to add a trustline
+          </p>
+          <ol className="list-decimal list-inside space-y-1 text-amber-100/80 text-sm">
+            <li>Open your Stellar wallet (Freighter, Albedo, etc.)</li>
+            <li>Navigate to &quot;Assets&quot; or &quot;Trustlines&quot;</li>
+            <li>
+              Search for{' '}
+              <span className="font-mono font-semibold">{error.assetCode}</span>{' '}
+              and click &quot;Add&quot; or &quot;Trust&quot;
+            </li>
+            <li>Confirm the transaction (costs ~0.5 XLM reserve)</li>
+            <li>Return here and retry the trade</li>
+          </ol>
+        </div>
+      )}
+
+      {/* External links */}
+      <div className="flex flex-wrap gap-3 pt-1">
+        {isBuyer && (
+          <>
+            <a
+              href="https://www.freighter.app/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 text-xs text-amber-300 hover:text-amber-100 underline underline-offset-2 transition-colors"
+            >
+              Freighter
+              <ExternalLink className="h-3 w-3" />
+            </a>
+            <a
+              href="https://albedo.link/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 text-xs text-amber-300 hover:text-amber-100 underline underline-offset-2 transition-colors"
+            >
+              Albedo
+              <ExternalLink className="h-3 w-3" />
+            </a>
+          </>
+        )}
+        <a
+          href={docsUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1 text-xs text-amber-300 hover:text-amber-100 underline underline-offset-2 transition-colors"
+        >
+          Trustless Work Docs
+          <ExternalLink className="h-3 w-3" />
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/hooks/use-escrow-actions.ts
+++ b/apps/web/hooks/use-escrow-actions.ts
@@ -6,6 +6,7 @@ import { useInitializeTrade } from '@/hooks/use-trades';
 import { useEscrowSelection } from '@/hooks/use-escrow-selection';
 import type { Escrow } from '@pacto-p2p/types';
 import { ReportPaymentData } from '@/lib/types/escrow';
+import { TrustlineError } from '@/utils/stellar/TrustlineError';
 
 export function useEscrowActions() {
   const [isReportPaymentLoading, setIsReportPaymentLoading] = useState(false);
@@ -77,7 +78,10 @@ export function useEscrowActions() {
       });
       sileo.success({ title: 'Funds deposited successfully' });
       return true;
-    } catch {
+    } catch (error) {
+      // Re-throw TrustlineError so the UI layer can show the TrustlineBanner.
+      // Show a generic toast for all other errors.
+      if (error instanceof TrustlineError) throw error;
       sileo.error({ title: 'Error depositing funds' });
       return false;
     }
@@ -114,7 +118,9 @@ export function useEscrowActions() {
       });
       sileo.success({ title: 'Funds released successfully' });
       return true;
-    } catch {
+    } catch (error) {
+      // Re-throw TrustlineError so the UI layer can show the TrustlineBanner.
+      if (error instanceof TrustlineError) throw error;
       sileo.error({ title: 'Error releasing funds' });
       return false;
     }

--- a/apps/web/hooks/use-escrows.ts
+++ b/apps/web/hooks/use-escrows.ts
@@ -16,6 +16,7 @@ import type { CreateEscrowData } from '@/lib/types';
 import { TradesService } from '@/lib/services/trades';
 import useGlobalAuthenticationStore from '@/store/wallet.store';
 import { useInitializeTrade } from './use-trades';
+import { TrustlineError } from '@/utils/stellar/TrustlineError';
 
 const MAX_ACTIVE_ESCROWS_PER_BUYER_PER_LISTING = 1;
 

--- a/apps/web/hooks/use-trades.ts
+++ b/apps/web/hooks/use-trades.ts
@@ -17,7 +17,7 @@ import {
 import type { CreateEscrowData } from '@/lib/types';
 import { signTransaction } from '@/lib/wallet';
 import useGlobalAuthenticationStore from '@/store/wallet.store';
-import { getTrustline } from '@/utils/getTrustline';
+import { getTrustline, getTrustlineName } from '@/utils/getTrustline';
 import { hasTrustline } from '@/utils/stellar/hasTrustline';
 import { TrustlineError } from '@/utils/stellar/TrustlineError';
 
@@ -234,8 +234,10 @@ export const useInitializeTrade = () => {
 
     // Validate trustlines before funding — seller (releaseSigner) must be able
     // to send the token, and buyer (receiver) must be able to receive it.
-    const escrowAssetCode = escrow.trustline.symbol;
+    // The TLW Trustline type only provides `address` (the issuer G... address).
+    // We derive the human-readable symbol from that address via getTrustlineName.
     const escrowAssetIssuer = escrow.trustline.address;
+    const escrowAssetCode = getTrustlineName(escrowAssetIssuer);
 
     if (escrowAssetCode && escrowAssetIssuer) {
       const [sellerHasTrustline, buyerHasTrustline] = await Promise.all([

--- a/apps/web/hooks/use-trades.ts
+++ b/apps/web/hooks/use-trades.ts
@@ -18,7 +18,8 @@ import type { CreateEscrowData } from '@/lib/types';
 import { signTransaction } from '@/lib/wallet';
 import useGlobalAuthenticationStore from '@/store/wallet.store';
 import { getTrustline } from '@/utils/getTrustline';
-import { supabase } from '@/lib/supabase';
+import { hasTrustline } from '@/utils/stellar/hasTrustline';
+import { TrustlineError } from '@/utils/stellar/TrustlineError';
 
 export const useInitializeTrade = () => {
   const { deployEscrow } = useInitializeEscrow();
@@ -85,6 +86,21 @@ export const useInitializeTrade = () => {
         ? String(payload.listing.id)
         : crypto.randomUUID();
     const engagementId = `${listingId}-${Date.now()}`;
+
+    // Validate that both parties have the required Stellar trustline before
+    // attempting any on-chain operation. A missing trustline causes an opaque
+    // `op_no_trust` error from Stellar — we surface a clear message instead.
+    const [sellerHasTrustline, buyerHasTrustline] = await Promise.all([
+      hasTrustline(seller, trustline.symbol, trustline.address),
+      hasTrustline(buyer, trustline.symbol, trustline.address),
+    ]);
+
+    if (!sellerHasTrustline) {
+      throw new TrustlineError('seller', trustline.symbol);
+    }
+    if (!buyerHasTrustline) {
+      throw new TrustlineError('buyer', trustline.symbol);
+    }
 
     const finalPayload = {
       signer: address,
@@ -214,6 +230,33 @@ export const useInitializeTrade = () => {
 
     if (!escrow.amount || escrow.amount <= 0) {
       throw new Error('Invalid escrow amount.');
+    }
+
+    // Validate trustlines before funding — seller (releaseSigner) must be able
+    // to send the token, and buyer (receiver) must be able to receive it.
+    const escrowAssetCode = escrow.trustline.symbol;
+    const escrowAssetIssuer = escrow.trustline.address;
+
+    if (escrowAssetCode && escrowAssetIssuer) {
+      const [sellerHasTrustline, buyerHasTrustline] = await Promise.all([
+        hasTrustline(
+          escrow.roles.releaseSigner,
+          escrowAssetCode,
+          escrowAssetIssuer
+        ),
+        hasTrustline(
+          escrow.roles.receiver,
+          escrowAssetCode,
+          escrowAssetIssuer
+        ),
+      ]);
+
+      if (!sellerHasTrustline) {
+        throw new TrustlineError('seller', escrowAssetCode);
+      }
+      if (!buyerHasTrustline) {
+        throw new TrustlineError('buyer', escrowAssetCode);
+      }
     }
 
     const finalPayload: FundEscrowPayload = {

--- a/apps/web/utils/stellar/TrustlineError.ts
+++ b/apps/web/utils/stellar/TrustlineError.ts
@@ -1,0 +1,22 @@
+/**
+ * Typed error thrown when a required Stellar trustline is missing.
+ *
+ * Use `instanceof TrustlineError` in catch blocks to display the
+ * `TrustlineBanner` UI component instead of a generic error toast.
+ */
+export class TrustlineError extends Error {
+  readonly role: 'buyer' | 'seller';
+  readonly assetCode: string;
+
+  constructor(role: 'buyer' | 'seller', assetCode: string) {
+    const message =
+      role === 'seller'
+        ? `Seller wallet does not have a trustline for ${assetCode}. The seller must set it up in their Stellar wallet before trading.`
+        : `Your wallet does not have a trustline for ${assetCode}. Please add it in your Stellar wallet before proceeding.`;
+
+    super(message);
+    this.name = 'TrustlineError';
+    this.role = role;
+    this.assetCode = assetCode;
+  }
+}

--- a/apps/web/utils/stellar/hasTrustline.ts
+++ b/apps/web/utils/stellar/hasTrustline.ts
@@ -1,0 +1,38 @@
+/**
+ * Checks whether a Stellar account has an active trustline for a given asset.
+ *
+ * Queries the Horizon REST API — no SDK dependency required.
+ * Returns `false` (never throws) when the account doesn't exist or the network
+ * is unreachable, so callers can decide how to surface the error.
+ *
+ * @param accountAddress - Stellar G… address to check
+ * @param assetCode      - Token symbol, e.g. "USDC"
+ * @param assetIssuer    - Issuer address (G…) of the token
+ */
+export async function hasTrustline(
+  accountAddress: string,
+  assetCode: string,
+  assetIssuer: string
+): Promise<boolean> {
+  const isMainnet = process.env.NEXT_PUBLIC_STELLAR_NETWORK === 'mainnet';
+  const horizonBase = isMainnet
+    ? 'https://horizon.stellar.org'
+    : 'https://horizon-testnet.stellar.org';
+
+  try {
+    const res = await fetch(`${horizonBase}/accounts/${accountAddress}`);
+    if (!res.ok) return false;
+
+    const account = await res.json();
+
+    return (
+      account.balances?.some(
+        (b: { asset_code?: string; asset_issuer?: string }) =>
+          b.asset_code === assetCode && b.asset_issuer === assetIssuer
+      ) ?? false
+    );
+  } catch {
+    // Network error — treat as unknown / not verified
+    return false;
+  }
+}


### PR DESCRIPTION
Closes #113

Related: #104 (role mapping) | #105 (canReportPayment)

---

## Summary

Before this PR, the escrow flow had no check that the buyer's or seller's Stellar wallet held a trustline for the escrow asset (USDC, CRCX, MXNX). A missing trustline caused a silent `op_no_trust` Stellar error that users couldn't understand or act on.

## What Changed

### New files
- [utils/stellar/hasTrustline.ts](cci:7://file:///Users/amankoli/pacto-p2p/apps/web/utils/stellar/hasTrustline.ts:0:0-0:0) — queries Stellar Horizon API to check if a wallet holds a trustline for a given asset (code + issuer). Falls back to `false` on network errors, never throws.
- [utils/stellar/TrustlineError.ts](cci:7://file:///Users/amankoli/pacto-p2p/apps/web/utils/stellar/TrustlineError.ts:0:0-0:0) — typed error class with `role: 'buyer' | 'seller'` and `assetCode`, so catch blocks can render the right UI.
- [components/shared/TrustlineBanner.tsx](cci:7://file:///Users/amankoli/pacto-p2p/apps/web/components/shared/TrustlineBanner.tsx:0:0-0:0) — amber banner with role-specific messaging, step-by-step Freighter/Albedo setup guide, and links to TrustlessWork docs.

### Modified files
- [hooks/use-trades.ts](cci:7://file:///Users/amankoli/pacto-p2p/apps/web/hooks/use-trades.ts:0:0-0:0) — parallel [hasTrustline()](cci:1://file:///Users/amankoli/pacto-p2p/apps/web/utils/stellar/hasTrustline.ts:0:0-37:1) checks (via `Promise.all`) in **both** [initializeTrade](cci:1://file:///Users/amankoli/pacto-p2p/apps/web/hooks/use-trades.ts:33:2-140:4) (before `deployEscrow`) and [depositFunds](cci:1://file:///Users/amankoli/pacto-p2p/apps/web/hooks/use-trades.ts:195:2-270:4) (before `fundEscrow`)
- [hooks/use-escrow-actions.ts](cci:7://file:///Users/amankoli/pacto-p2p/apps/web/hooks/use-escrow-actions.ts:0:0-0:0) — [handleDeposit](cci:1://file:///Users/amankoli/pacto-p2p/apps/web/hooks/use-escrow-actions.ts:71:2-87:4) and [handleReleaseFunds](cci:1://file:///Users/amankoli/pacto-p2p/apps/web/hooks/use-escrow-actions.ts:107:2-126:4) re-throw [TrustlineError](cci:2://file:///Users/amankoli/pacto-p2p/apps/web/utils/stellar/TrustlineError.ts:6:0-21:1) so the UI can show the banner; all other errors still show a toast
- [components/escrow/EscrowDetailsModal.tsx](cci:7://file:///Users/amankoli/pacto-p2p/apps/web/components/escrow/EscrowDetailsModal.tsx:0:0-0:0) — catches [TrustlineError](cci:2://file:///Users/amankoli/pacto-p2p/apps/web/utils/stellar/TrustlineError.ts:6:0-21:1) from Deposit/Release buttons and renders [TrustlineBanner](cci:1://file:///Users/amankoli/pacto-p2p/apps/web/components/shared/TrustlineBanner.tsx:9:0-97:1) inline above the action grid
- [hooks/use-escrows.ts](cci:7://file:///Users/amankoli/pacto-p2p/apps/web/hooks/use-escrows.ts:0:0-0:0) — imports [TrustlineError](cci:2://file:///Users/amankoli/pacto-p2p/apps/web/utils/stellar/TrustlineError.ts:6:0-21:1) so `useCreateEscrow.onError` surfaces the full descriptive message
- [apps/web/.env.example](cci:7://file:///Users/amankoli/pacto-p2p/apps/web/.env.example:0:0-0:0) — added `NEXT_PUBLIC_STELLAR_NETWORK` documentation.

## Who is validated and when

| Role | Hook | Validated before |
|---|---|---|
| Seller (`releaseSigner`) | [initializeTrade](cci:1://file:///Users/amankoli/pacto-p2p/apps/web/hooks/use-trades.ts:33:2-140:4) + [depositFunds](cci:1://file:///Users/amankoli/pacto-p2p/apps/web/hooks/use-trades.ts:195:2-270:4) | `deployEscrow` + `fundEscrow` |
| Buyer (`receiver`) | [initializeTrade](cci:1://file:///Users/amankoli/pacto-p2p/apps/web/hooks/use-trades.ts:33:2-140:4) + [depositFunds](cci:1://file:///Users/amankoli/pacto-p2p/apps/web/hooks/use-trades.ts:195:2-270:4) | `deployEscrow` + `fundEscrow` |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a runtime Stellar network setting (mainnet/testnet).
  * Surface explicit trustline errors with an in-app warning banner and actionable setup steps, plus wallet and docs links for buyers.

* **Bug Fixes**
  * Preflight trustline checks to fail early and prevent opaque runtime failures during trade setup and funding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->