### PR TITLE
fix: canReportPayment allows buyer to report fiat payment before seller has funded the escrow

### DIFF
--- a/apps/web/lib/escrow-utils.ts
+++ b/apps/web/lib/escrow-utils.ts
@@ -49,7 +49,7 @@ export function canReportPayment(
   if (userRole !== 'buyer') return false;
   if (escrow.flags?.resolved || escrow.flags?.released) return false;
   if (escrow.milestones[0].status === 'pendingApproval') return false;
-  if (escrow.balance === 0) return false;
+  if ((escrow.balance ?? 0) <= 0) return false;
   return true;
 }
 


### PR DESCRIPTION
This PR fixes the bug in `canReportPayment` by adding a check to ensure the escrow is funded (`[escrow.balance > 0]`) before allowing the buyer to report payment. No errors were found after the change.

Closes #105 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented payment reporting when an escrow account has zero or missing balance, avoiding attempts to report payments without sufficient funds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->