### PR TITLE
docs: document deliberate TrustlessWork role semantics inversion

### DIFF
--- a/apps/web/components/escrow/EscrowCard.tsx
+++ b/apps/web/components/escrow/EscrowCard.tsx
@@ -78,7 +78,7 @@ export function EscrowCard({ escrow, onClick }: EscrowCardProps) {
             <div className="space-y-3">
               <div>
                 <p className="text-sm text-muted-foreground mb-1">
-                  Seller Address (TW Approver)
+                  Seller Address (releases crypto)
                 </p>
                 <div className="flex items-center gap-2 p-2 bg-muted/50 backdrop-blur-sm rounded-md break-all">
                   <span className="font-mono text-xs text-foreground">
@@ -89,7 +89,7 @@ export function EscrowCard({ escrow, onClick }: EscrowCardProps) {
               </div>
               <div>
                 <p className="text-sm text-muted-foreground mb-1">
-                  Buyer Address (TW Service Provider)
+                  Buyer Address (confirms fiat payment)
                 </p>
                 <div className="flex items-center gap-2 p-2 bg-muted/50 backdrop-blur-sm rounded-md break-all">
                   <span className="font-mono text-xs text-foreground">

--- a/apps/web/components/escrow/EscrowCard.tsx
+++ b/apps/web/components/escrow/EscrowCard.tsx
@@ -78,7 +78,7 @@ export function EscrowCard({ escrow, onClick }: EscrowCardProps) {
             <div className="space-y-3">
               <div>
                 <p className="text-sm text-muted-foreground mb-1">
-                  Seller Address
+                  Seller Address (TW Approver)
                 </p>
                 <div className="flex items-center gap-2 p-2 bg-muted/50 backdrop-blur-sm rounded-md break-all">
                   <span className="font-mono text-xs text-foreground">
@@ -89,7 +89,7 @@ export function EscrowCard({ escrow, onClick }: EscrowCardProps) {
               </div>
               <div>
                 <p className="text-sm text-muted-foreground mb-1">
-                  Buyer Address
+                  Buyer Address (TW Service Provider)
                 </p>
                 <div className="flex items-center gap-2 p-2 bg-muted/50 backdrop-blur-sm rounded-md break-all">
                   <span className="font-mono text-xs text-foreground">

--- a/apps/web/components/escrow/EscrowDetailsModal.tsx
+++ b/apps/web/components/escrow/EscrowDetailsModal.tsx
@@ -123,7 +123,7 @@ export function EscrowDetailsModal({
 
               <div className="space-y-3">
                 <div>
-                  <p className="text-sm text-muted-foreground mb-1">Seller</p>
+                  <p className="text-sm text-muted-foreground mb-1">Seller (TW Approver)</p>
                   <div className="flex items-center gap-2 p-3 bg-muted/50 backdrop-blur-sm rounded-lg break-all">
                     <User className="w-4 h-4 text-muted-foreground" />
                     <span className="font-mono text-sm text-foreground">
@@ -134,7 +134,7 @@ export function EscrowDetailsModal({
                 </div>
 
                 <div>
-                  <p className="text-sm text-muted-foreground mb-1">Buyer</p>
+                  <p className="text-sm text-muted-foreground mb-1">Buyer (TW Service Provider)</p>
                   <div className="flex items-center gap-2 p-3 bg-muted/50 backdrop-blur-sm rounded-lg break-all">
                     <User className="w-4 h-4 text-muted-foreground" />
                     <span className="font-mono text-sm text-foreground">

--- a/apps/web/components/escrow/EscrowDetailsModal.tsx
+++ b/apps/web/components/escrow/EscrowDetailsModal.tsx
@@ -123,7 +123,7 @@ export function EscrowDetailsModal({
 
               <div className="space-y-3">
                 <div>
-                  <p className="text-sm text-muted-foreground mb-1">Seller (TW Approver)</p>
+                  <p className="text-sm text-muted-foreground mb-1">Seller (releases crypto)</p>
                   <div className="flex items-center gap-2 p-3 bg-muted/50 backdrop-blur-sm rounded-lg break-all">
                     <User className="w-4 h-4 text-muted-foreground" />
                     <span className="font-mono text-sm text-foreground">
@@ -134,7 +134,7 @@ export function EscrowDetailsModal({
                 </div>
 
                 <div>
-                  <p className="text-sm text-muted-foreground mb-1">Buyer (TW Service Provider)</p>
+                  <p className="text-sm text-muted-foreground mb-1">Buyer (confirms fiat payment)</p>
                   <div className="flex items-center gap-2 p-3 bg-muted/50 backdrop-blur-sm rounded-lg break-all">
                     <User className="w-4 h-4 text-muted-foreground" />
                     <span className="font-mono text-sm text-foreground">

--- a/apps/web/hooks/use-escrows.ts
+++ b/apps/web/hooks/use-escrows.ts
@@ -326,8 +326,8 @@ export function useDisputeEscrow() {
       }
 
       const isParticipant =
-        address === escrow.roles.releaseSigner ||
-        address === escrow.roles.serviceProvider;
+        address === escrow.roles.releaseSigner || // = seller
+        address === escrow.roles.serviceProvider; // = buyer
       if (!isParticipant) {
         throw new Error('Only escrow participants can raise a dispute');
       }

--- a/apps/web/hooks/use-trades.ts
+++ b/apps/web/hooks/use-trades.ts
@@ -80,6 +80,9 @@ export const useInitializeTrade = () => {
       },
       title: `${payload.listing.token} trade - ${listingId}`,
       roles: {
+        // TW Role Inversion: Seller acts as 'approver' to maintain authorization
+        // over the crypto release. Buyer acts as 'serviceProvider' to submit
+        // the off-chain fiat payment evidence.
         approver: seller, // seller
         releaseSigner: seller, // seller
         serviceProvider: buyer, // buyer

--- a/apps/web/lib/escrow-utils.ts
+++ b/apps/web/lib/escrow-utils.ts
@@ -4,6 +4,8 @@ export function getEscrowRole(
   escrow: Escrow,
   userAddress: string
 ): 'buyer' | 'seller' | null {
+  // TW Role Inversion: serviceProvider = buyer (submits fiat payment evidence),
+  // approver = seller (verifies fiat receipt and releases crypto).
   if (escrow.roles.serviceProvider === userAddress) {
     return 'buyer';
   }
@@ -17,6 +19,7 @@ export function canReportPayment(
   escrow: Escrow,
   userRole: 'buyer' | 'seller'
 ): boolean {
+  // Only buyer (TW serviceProvider) reports off-chain fiat payment
   if (userRole !== 'buyer') return false;
   if (escrow.flags?.resolved || escrow.flags?.released) return false;
   if (escrow.milestones[0].status === 'pendingApproval') return false;
@@ -27,6 +30,7 @@ export function canConfirmPayment(
   escrow: Escrow,
   userRole: 'buyer' | 'seller'
 ): boolean {
+  // Only seller (TW approver) verifies fiat receipt
   if (userRole !== 'seller') return false;
   return !escrow.milestones[0].approved;
 }
@@ -35,6 +39,7 @@ export function canDeposit(
   escrow: Escrow,
   userRole: 'buyer' | 'seller'
 ): boolean {
+  // Only seller funds the initial crypto escrow
   if (userRole !== 'seller') return false;
   if (escrow.flags?.released || escrow.flags?.resolved) return false;
   return escrow.balance === 0;
@@ -44,6 +49,7 @@ export function canReleaseFunds(
   escrow: Escrow,
   userRole: 'buyer' | 'seller'
 ): boolean {
+  // Only seller (TW releaseSigner) can trigger final release after approval
   if (userRole !== 'seller') return false;
   if (!escrow.milestones[0].approved) return false;
   return escrow.balance !== 0;

--- a/apps/web/lib/types/escrow.ts
+++ b/apps/web/lib/types/escrow.ts
@@ -15,7 +15,14 @@ export interface EscrowFlags {
 }
 
 export interface EscrowRoles {
+  // TW Role Inversion: approver = seller, serviceProvider = buyer
+  /**
+   * The address of the approver (seller in the Trust Wallet context).
+   */
   approver: string;
+  /**
+   * The address of the service provider (buyer in the Trust Wallet context).
+   */
   serviceProvider: string;
 }
 

--- a/apps/web/lib/types/escrow.ts
+++ b/apps/web/lib/types/escrow.ts
@@ -17,11 +17,13 @@ export interface EscrowFlags {
 export interface EscrowRoles {
   // TW Role Inversion: approver = seller, serviceProvider = buyer
   /**
-   * The address of the approver (seller in the Trust Wallet context).
+   * The address of the approver (seller in the TrustlessWork context).
+   * The seller releases crypto after verifying fiat payment was received.
    */
   approver: string;
   /**
-   * The address of the service provider (buyer in the Trust Wallet context).
+   * The address of the service provider (buyer in the TrustlessWork context).
+   * The buyer confirms fiat payment by submitting off-chain evidence.
    */
   serviceProvider: string;
 }


### PR DESCRIPTION
## Summary
Closes #104 by implementing comprehensive documentation for the deliberate inversion of TrustlessWork (TW) escrow roles within the Pacto P2P protocol.

## Root Cause
To preserve security and correct operational behavior in a non-custodial fiat-to-crypto environment, roles are mapped as follows:

- **Seller** → TW `approver` (controls final release of crypto assets)  
- **Buyer** → TW `serviceProvider` (reports off-chain fiat payment status)  

While mechanically correct, this mapping deviates from official TrustlessWork conventions, where the `serviceProvider` typically represents the recipient of services or crypto.

This discrepancy introduces a significant maintenance risk, particularly for:
- New feature development  
- Dispute resolution flows  
- Contributor onboarding and understanding  

## Fix Implemented

A full documentation sweep was carried out across the application stack:

### Hooks & Utilities
- Added explanatory comments to:
  - Role initialization in `use-trades.ts`  
  - Permission logic in `escrow-utils.ts`  
  - Participant validation in `use-escrows.ts`  

### Data Layer
- Documented the `EscrowRoles` interface mapping in:
  - `lib/types/escrow.ts`  

### UI Layer
- Updated user-facing labels for clarity:
  - `EscrowCard.tsx`  
  - `EscrowDetailsModal.tsx`  

- Replaced ambiguous labels with explicit mappings:
  - **"Seller (TW Approver)"**  
  - **"Buyer (TW Service Provider)"**  

## Testing Performed

- **Manual Audit**  
  - Verified consistency of documentation across all modified files  

- **Safety Check**  
  - Confirmed zero impact on functional logic and smart contract execution paths  

- **Build Verification**  
  - Ensured no syntax, type, or UI regressions from added comments and label updates  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated escrow UI labels to clarify participant roles: "Seller (releases crypto)" and "Buyer (confirms fiat payment)".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->