### PR TITLE
 feat: add dispute resolution admin UI with platform wallet guard

### DIFF
--- a/apps/web/app/dashboard/admin/page.tsx
+++ b/apps/web/app/dashboard/admin/page.tsx
@@ -12,6 +12,7 @@ import {
   TransactionList,
   UserManagement,
   MerchantApplications,
+  DisputeManagement,
 } from '@/components/admin';
 import {
   getDefaultTokens,
@@ -104,6 +105,9 @@ export default function AdminPage() {
           <TabsTrigger value="merchant-applications" className="bg-card/60 hover:bg-card/80 text-muted-foreground hover:text-foreground data-[state=active]:bg-emerald-500 data-[state=active]:text-white data-[state=active]:shadow-md transition-all duration-200 rounded-md px-4 py-1.5 text-sm font-medium border border-transparent cursor-pointer whitespace-nowrap">
             Merchant Applications
           </TabsTrigger>
+          <TabsTrigger value="disputes" className="bg-card/60 hover:bg-card/80 text-muted-foreground hover:text-foreground data-[state=active]:bg-emerald-500 data-[state=active]:text-white data-[state=active]:shadow-md transition-all duration-200 rounded-md px-4 py-1.5 text-sm font-medium border border-transparent cursor-pointer whitespace-nowrap">
+            Disputes
+          </TabsTrigger>
         </TabsList>
 
         <TabsContent value="tokens">
@@ -137,6 +141,10 @@ export default function AdminPage() {
 
         <TabsContent value="merchant-applications">
           <MerchantApplications />
+        </TabsContent>
+
+        <TabsContent value="disputes">
+          <DisputeManagement />
         </TabsContent>
       </Tabs>
     </div>

--- a/apps/web/components/admin/DisputeManagement.tsx
+++ b/apps/web/components/admin/DisputeManagement.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import { useState } from 'react';
+import { Loader2, Scale } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { useDisputedEscrows } from '@/hooks/use-disputed-escrows';
+import { DisputeResolutionModal } from './DisputeResolutionModal';
+import type { Escrow } from '@pacto-p2p/types';
+
+export function DisputeManagement() {
+  const { data: escrows, isLoading, error, refetch } = useDisputedEscrows();
+  const [selectedEscrow, setSelectedEscrow] = useState<Escrow | null>(null);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Loader2 className="w-8 h-8 animate-spin text-gray-400" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="text-center py-12">
+        <p className="text-red-600">
+          Failed to load disputed escrows. Please try again.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h2 className="text-2xl font-semibold">Dispute Management</h2>
+        <Badge
+          variant="outline"
+          className="bg-red-100 text-red-800 border-red-200 dark:bg-red-900/30 dark:text-red-400 dark:border-red-800"
+        >
+          {escrows?.length ?? 0} open
+        </Badge>
+      </div>
+
+      {!escrows || escrows.length === 0 ? (
+        <div className="flex flex-col items-center gap-3 py-16 rounded-lg border border-gray-200 dark:border-gray-700">
+          <Scale className="h-10 w-10 text-muted-foreground/40" />
+          <p className="text-muted-foreground">No disputed escrows found.</p>
+        </div>
+      ) : (
+        <div className="rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
+          <table className="w-full">
+            <thead>
+              <tr className="border-b border-gray-200 dark:border-gray-700 bg-muted/50">
+                <th className="text-left py-3 px-4 font-medium">Contract ID</th>
+                <th className="text-left py-3 px-4 font-medium">Buyer</th>
+                <th className="text-left py-3 px-4 font-medium">Seller</th>
+                <th className="text-left py-3 px-4 font-medium">Amount</th>
+                <th className="text-left py-3 px-4 font-medium">Balance</th>
+                <th className="text-right py-3 px-4 font-medium">Action</th>
+              </tr>
+            </thead>
+            <tbody>
+              {escrows.map((escrow) => (
+                <tr
+                  key={escrow.contractId ?? escrow.engagementId}
+                  className="border-b border-gray-200 dark:border-gray-700 last:border-0 hover:bg-muted/30"
+                >
+                  <td className="py-3 px-4 font-mono text-xs text-muted-foreground max-w-[140px] truncate">
+                    {escrow.contractId ?? '—'}
+                  </td>
+                  <td className="py-3 px-4 font-mono text-xs text-muted-foreground max-w-[140px] truncate">
+                    {/* buyer = serviceProvider due to role inversion */}
+                    {escrow.roles.serviceProvider}
+                  </td>
+                  <td className="py-3 px-4 font-mono text-xs text-muted-foreground max-w-[140px] truncate">
+                    {/* seller = approver due to role inversion */}
+                    {escrow.roles.approver}
+                  </td>
+                  <td className="py-3 px-4 text-sm">
+                    {escrow.amount} {escrow.trustline?.name ?? ''}
+                  </td>
+                  <td className="py-3 px-4 text-sm font-semibold">
+                    {escrow.balance ?? '—'} {escrow.trustline?.name ?? ''}
+                  </td>
+                  <td className="py-3 px-4 text-right">
+                    <Button
+                      size="sm"
+                      className="btn-emerald"
+                      onClick={() => setSelectedEscrow(escrow)}
+                    >
+                      Resolve
+                    </Button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {selectedEscrow && (
+        <DisputeResolutionModal
+          escrow={selectedEscrow}
+          onClose={() => setSelectedEscrow(null)}
+          onResolved={() => {
+            setSelectedEscrow(null);
+            refetch();
+          }}
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/admin/DisputeResolutionModal.tsx
+++ b/apps/web/components/admin/DisputeResolutionModal.tsx
@@ -1,0 +1,210 @@
+'use client';
+
+import { useState } from 'react';
+import { AlertTriangle, Loader2, ShieldAlert } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/ui/dialog';
+import type { Escrow } from '@pacto-p2p/types';
+import { useEscrowActions } from '@/hooks/use-escrow-actions';
+import useGlobalAuthenticationStore from '@/store/wallet.store';
+
+interface DisputeResolutionModalProps {
+  escrow: Escrow;
+  onClose: () => void;
+  onResolved: () => void;
+}
+
+export function DisputeResolutionModal({
+  escrow,
+  onClose,
+  onResolved,
+}: DisputeResolutionModalProps) {
+  const { address } = useGlobalAuthenticationStore();
+  const { handleResolveDispute, isResolveDisputeLoading } = useEscrowActions();
+
+  const platformAddress = process.env.NEXT_PUBLIC_ROLE_ADDRESS ?? '';
+  const isPlatformWallet =
+    !!address && !!platformAddress && address === platformAddress;
+
+  const currentBalance = escrow.balance ?? escrow.amount ?? 0;
+
+  const [buyerAmount, setBuyerAmount] = useState<string>('');
+  const [sellerAmount, setSellerAmount] = useState<string>('');
+
+  const buyer = escrow.roles.serviceProvider; // buyer = serviceProvider (role inversion)
+  const seller = escrow.roles.approver; // seller = approver (role inversion)
+
+  const parsedBuyer = parseFloat(buyerAmount) || 0;
+  const parsedSeller = parseFloat(sellerAmount) || 0;
+  const total = parseFloat((parsedBuyer + parsedSeller).toFixed(7));
+  const isValidSum = Math.abs(total - currentBalance) < 0.0000001;
+
+  const handleBuyerChange = (value: string) => {
+    setBuyerAmount(value);
+    const parsed = parseFloat(value) || 0;
+    const remaining = parseFloat((currentBalance - parsed).toFixed(7));
+    setSellerAmount(remaining >= 0 ? String(remaining) : '0');
+  };
+
+  const handleSellerChange = (value: string) => {
+    setSellerAmount(value);
+    const parsed = parseFloat(value) || 0;
+    const remaining = parseFloat((currentBalance - parsed).toFixed(7));
+    setBuyerAmount(remaining >= 0 ? String(remaining) : '0');
+  };
+
+  const handleSubmit = async () => {
+    if (!isValidSum || !isPlatformWallet) return;
+
+    const distributions = [
+      { address: buyer, amount: parsedBuyer },
+      { address: seller, amount: parsedSeller },
+    ];
+
+    const success = await handleResolveDispute(escrow, distributions);
+    if (success) {
+      onResolved();
+      onClose();
+    }
+  };
+
+  return (
+    <Dialog open onOpenChange={onClose}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Resolve Dispute</DialogTitle>
+          <DialogDescription>
+            Distribute the escrow balance between buyer and seller. The sum must
+            equal the current balance.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          {/* Escrow info */}
+          <div className="rounded-lg border border-border/50 bg-muted/30 p-3 space-y-1 text-sm">
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">Contract ID</span>
+              <span className="font-mono text-xs truncate max-w-[200px]">
+                {escrow.contractId}
+              </span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">Current balance</span>
+              <span className="font-semibold">
+                {currentBalance} {escrow.trustline?.name ?? ''}
+              </span>
+            </div>
+          </div>
+
+          {/* Platform wallet guard */}
+          {!isPlatformWallet && (
+            <div className="flex items-start gap-2 rounded-lg border border-yellow-500/40 bg-yellow-500/10 p-3 text-sm text-yellow-700 dark:text-yellow-400">
+              <ShieldAlert className="mt-0.5 h-4 w-4 shrink-0" />
+              <span>
+                Connect the platform wallet ({platformAddress || 'not configured'}) to resolve disputes.
+                Currently connected: {address || 'none'}
+              </span>
+            </div>
+          )}
+
+          {/* Distribution inputs */}
+          <div className="space-y-3">
+            <div className="space-y-1">
+              <Label htmlFor="buyer-amount">
+                Buyer{' '}
+                <span className="text-muted-foreground font-normal font-mono text-xs">
+                  ({buyer})
+                </span>
+              </Label>
+              <Input
+                id="buyer-amount"
+                type="number"
+                min="0"
+                max={currentBalance}
+                step="0.0000001"
+                value={buyerAmount}
+                onChange={(e) => handleBuyerChange(e.target.value)}
+                placeholder="0"
+                disabled={!isPlatformWallet || isResolveDisputeLoading}
+              />
+            </div>
+
+            <div className="space-y-1">
+              <Label htmlFor="seller-amount">
+                Seller{' '}
+                <span className="text-muted-foreground font-normal font-mono text-xs">
+                  ({seller})
+                </span>
+              </Label>
+              <Input
+                id="seller-amount"
+                type="number"
+                min="0"
+                max={currentBalance}
+                step="0.0000001"
+                value={sellerAmount}
+                onChange={(e) => handleSellerChange(e.target.value)}
+                placeholder="0"
+                disabled={!isPlatformWallet || isResolveDisputeLoading}
+              />
+            </div>
+          </div>
+
+          {/* Sum validation feedback */}
+          {(buyerAmount || sellerAmount) && !isValidSum && (
+            <div className="flex items-center gap-2 text-sm text-red-600 dark:text-red-400">
+              <AlertTriangle className="h-4 w-4 shrink-0" />
+              <span>
+                Sum ({total}) must equal current balance ({currentBalance}).
+              </span>
+            </div>
+          )}
+
+          {(buyerAmount || sellerAmount) && isValidSum && (
+            <div className="text-sm text-emerald-600 dark:text-emerald-400">
+              ✓ Distribution sums to {total} — ready to submit.
+            </div>
+          )}
+        </div>
+
+        <div className="flex justify-end gap-2 pt-2">
+          <Button
+            variant="ghost"
+            onClick={onClose}
+            disabled={isResolveDisputeLoading}
+          >
+            Cancel
+          </Button>
+          <Button
+            className="btn-emerald"
+            onClick={handleSubmit}
+            disabled={
+              !isPlatformWallet ||
+              !isValidSum ||
+              !buyerAmount ||
+              !sellerAmount ||
+              isResolveDisputeLoading
+            }
+          >
+            {isResolveDisputeLoading ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Resolving…
+              </>
+            ) : (
+              'Resolve Dispute'
+            )}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/components/admin/index.ts
+++ b/apps/web/components/admin/index.ts
@@ -10,3 +10,5 @@ export { MerchantApplications } from './MerchantApplications';
 export { MerchantApplicationCard } from './MerchantApplicationCard';
 export { MerchantApplicationModal } from './MerchantApplicationModal';
 export { MerchantApplicationFilters } from './MerchantApplicationFilters';
+export { DisputeManagement } from './DisputeManagement';
+export { DisputeResolutionModal } from './DisputeResolutionModal';

--- a/apps/web/hooks/use-disputed-escrows.ts
+++ b/apps/web/hooks/use-disputed-escrows.ts
@@ -1,0 +1,48 @@
+'use client';
+
+import type { Escrow } from '@pacto-p2p/types';
+import { useGetEscrowsFromIndexerByRole } from '@trustless-work/escrow';
+import { useQuery } from '@tanstack/react-query';
+
+/**
+ * Fetches all escrows where the platform is the disputeResolver and status=disputed.
+ * Uses the TrustlessWork indexer directly since escrows may not be persisted in Supabase (#102).
+ */
+export function useDisputedEscrows() {
+  const { getEscrowsByRole } = useGetEscrowsFromIndexerByRole();
+  const roleAddress = process.env.NEXT_PUBLIC_ROLE_ADDRESS;
+  const apiKey = process.env.NEXT_PUBLIC_TLW_API_KEY;
+
+  return useQuery({
+    queryKey: ['admin', 'disputed-escrows'],
+    queryFn: async (): Promise<Escrow[]> => {
+      if (!apiKey) {
+        throw new Error(
+          'Trustless Work API key is missing. Please set NEXT_PUBLIC_TLW_API_KEY environment variable.'
+        );
+      }
+
+      if (!roleAddress) {
+        throw new Error(
+          'Platform address is not configured. Set NEXT_PUBLIC_ROLE_ADDRESS environment variable.'
+        );
+      }
+
+      const escrows = await getEscrowsByRole({
+        role: 'disputeResolver',
+        roleAddress,
+        status: 'inDispute',
+        type: 'single-release',
+        validateOnChain: false,
+      });
+
+      if (!escrows) {
+        throw new Error('Failed to fetch disputed escrows');
+      }
+
+      return escrows;
+    },
+    enabled: !!roleAddress && !!apiKey,
+    staleTime: 1000 * 30, // 30 seconds — disputes are time-sensitive
+  });
+}

--- a/apps/web/hooks/use-escrow-actions.ts
+++ b/apps/web/hooks/use-escrow-actions.ts
@@ -3,7 +3,7 @@
 import { useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { sileo } from 'sileo';
-import { useInitializeTrade } from '@/hooks/use-trades';
+import { useInitializeTrade, type DisputeDistribution } from '@/hooks/use-trades';
 import { useEscrowSelection } from '@/hooks/use-escrow-selection';
 import type { Escrow } from '@pacto-p2p/types';
 import { ReportPaymentData } from '@/lib/types/escrow';
@@ -12,12 +12,14 @@ import { TrustlineError } from '@/utils/stellar/TrustlineError';
 export function useEscrowActions() {
   const [isReportPaymentLoading, setIsReportPaymentLoading] = useState(false);
   const [isCancelEscrowLoading, setIsCancelEscrowLoading] = useState(false);
+  const [isResolveDisputeLoading, setIsResolveDisputeLoading] = useState(false);
   const queryClient = useQueryClient();
   const { selectEscrow } = useEscrowSelection();
   const {
     reportPayment,
     depositFunds,
     disputeEscrow,
+    resolveDispute,
     releaseFunds,
     confirmPayment,
     cancelEscrow,
@@ -109,6 +111,38 @@ export function useEscrowActions() {
     }
   };
 
+  const handleResolveDispute = async (
+    escrow: Escrow,
+    distributions: DisputeDistribution[]
+  ) => {
+    setIsResolveDisputeLoading(true);
+    try {
+      await resolveDispute(escrow, distributions);
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['escrows'] }),
+        queryClient.invalidateQueries({ queryKey: ['trades'] }),
+        queryClient.invalidateQueries({ queryKey: ['admin', 'disputed-escrows'] }),
+      ]);
+      selectEscrow({
+        ...escrow,
+        flags: {
+          ...escrow.flags,
+          resolved: true,
+        },
+      });
+      sileo.success({ title: 'Dispute resolved successfully' });
+      return true;
+    } catch (error) {
+      sileo.error({
+        title: 'Error resolving dispute',
+        description: error instanceof Error ? error.message : 'Unknown error',
+      });
+      return false;
+    } finally {
+      setIsResolveDisputeLoading(false);
+    }
+  };
+
   const handleReleaseFunds = async (escrow: Escrow) => {
     try {
       await releaseFunds(escrow);
@@ -159,12 +193,14 @@ export function useEscrowActions() {
     // State
     isReportPaymentLoading,
     isCancelEscrowLoading,
+    isResolveDisputeLoading,
 
     // Actions
     handleReportPayment,
     handleConfirmPayment,
     handleDeposit,
     handleDisputeEscrow,
+    handleResolveDispute,
     handleReleaseFunds,
     handleCancelEscrow,
   };

--- a/apps/web/hooks/use-trades.ts
+++ b/apps/web/hooks/use-trades.ts
@@ -12,6 +12,7 @@ import {
   useFundEscrow,
   useInitializeEscrow,
   useReleaseFunds,
+  useResolveDispute,
   useSendTransaction,
   useStartDispute,
 } from '@trustless-work/escrow';
@@ -28,11 +29,17 @@ import {
 } from '@/lib/escrow-utils';
 import { TradesService } from '@/lib/services/trades';
 
+export interface DisputeDistribution {
+  address: string;
+  amount: number;
+}
+
 export const useInitializeTrade = () => {
   const { deployEscrow } = useInitializeEscrow();
   const { changeMilestoneStatus } = useChangeMilestoneStatus();
   const { fundEscrow } = useFundEscrow();
   const { startDispute } = useStartDispute();
+  const { resolveDispute: resolveDisputeEscrow } = useResolveDispute();
   const { approveMilestone } = useApproveMilestone();
   const { releaseFunds: releaseFundsEscrow } = useReleaseFunds();
   const { sendTransaction } = useSendTransaction();
@@ -473,12 +480,70 @@ export const useInitializeTrade = () => {
     return { engagementId: escrow.engagementId };
   };
 
+  const resolveDispute = async (
+    escrow: Escrow,
+    distributions: DisputeDistribution[]
+  ) => {
+    if (!address) {
+      throw new Error(
+        'Wallet address is required. Please connect your wallet.'
+      );
+    }
+
+    if (!escrow.contractId) {
+      throw new Error('Escrow contract ID is required.');
+    }
+
+    const disputeResolver = process.env.NEXT_PUBLIC_ROLE_ADDRESS;
+    if (!disputeResolver) {
+      throw new Error(
+        'Platform address is not configured. Set NEXT_PUBLIC_ROLE_ADDRESS environment variable.'
+      );
+    }
+
+    const finalPayload = {
+      contractId: escrow.contractId,
+      disputeResolver,
+      distributions: distributions as [{ address: string; amount: number }],
+    };
+
+    const { unsignedTransaction } = await resolveDisputeEscrow(
+      finalPayload,
+      'single-release'
+    );
+
+    if (!unsignedTransaction) {
+      throw new Error(
+        'Unsigned transaction is missing from resolveDispute response.'
+      );
+    }
+
+    const signedTxXdr = await signTransaction({
+      unsignedTransaction,
+      address,
+    });
+
+    if (!signedTxXdr) {
+      throw new Error('Signed transaction is missing.');
+    }
+
+    const response = await sendTransaction(signedTxXdr);
+
+    if (response.status !== 'SUCCESS') {
+      throw new Error('Transaction failed to send');
+    }
+
+    const txHash = extractTxHash(response);
+    return { txHash, contractId: escrow.contractId };
+  };
+
   return {
     initializeTrade,
     reportPayment,
     confirmPayment,
     depositFunds,
     disputeEscrow,
+    resolveDispute,
     releaseFunds,
     cancelEscrow,
   };


### PR DESCRIPTION
Closes #103 

  ## Summary
  Implements the missing dispute resolution flow for the Pacto admin panel. Previously, escrows marked as `disputed` had
   their funds permanently frozen with no way to resolve them. This PR adds the complete resolution path: from listing
  disputed escrows to distributing funds between buyer and seller on-chain.

  ## What was built
  - **Admin Disputes tab** — fetches disputed escrows directly from the TrustlessWork indexer (`role=disputeResolver`,
  `status=inDispute`)
  - **Resolution modal** — distribution form with real-time validation (`sum === balance`) and platform wallet guard
  - **`resolveDispute` action** — uses `useResolveDispute` from `@trustless-work/escrow` SDK, signed with the platform
  wallet and broadcast via `useSendTransaction`

  ## Known limitations
  - Escrow balance is sourced from the indexer's `escrow.balance` field. An explicit call to `GET
  /helper/get-multiple-escrow-balance` for live pre-resolution verification remains as a follow-up improvement.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Disputes tab to the admin dashboard for viewing disputed escrows
  * Admins can now see disputed transactions in a table with contract details and balances
  * New dispute resolution capability allowing admins to distribute funds between transaction parties

<!-- end of auto-generated comment: release notes by coderabbit.ai -->