### PR TITLE
#108 feat: implement real-time escrow state updates — 5-minute stale cache means users miss counterparty actions

### DIFF
--- a/apps/web/hooks/use-escrows.ts
+++ b/apps/web/hooks/use-escrows.ts
@@ -93,6 +93,7 @@ const STALE_TIME = {
   DASHBOARD_LIST: 1000 * 60 * 5, // 5 minutes: sufficient for display
   DETAIL_PAGE: 1000 * 30, // 30 seconds: slightly fresher for detail views
   CRITICAL_FLOW: 0, // Immediate: before any financial action
+  ACTIVE_ESCROW_POLLING: 1000 * 15, // 15 seconds: keep active trades fresh
 } as const;
 
 const VALIDATE_ON_CHAIN = {
@@ -102,11 +103,16 @@ const VALIDATE_ON_CHAIN = {
   BACKGROUND_REFETCH: false, // Reduces load; validation on interaction
 } as const;
 
+const REFETCH_INTERVAL = {
+  ACTIVE_ESCROW_POLLING: 1000 * 30, // 30 seconds polling for active escrows
+} as const;
+
 interface UseEscrowsByRoleQueryParams
   extends GetEscrowsFromIndexerByRoleParams {
   enabled?: boolean;
   validateOnChain?: boolean;
   staleTime?: number;
+  refetchInterval?: number | false;
   context?: 'dashboard-list' | 'detail-page' | 'critical-flow' | 'background-refetch';
 }
 
@@ -115,6 +121,7 @@ interface UseEscrowsBySignerQueryParams
   enabled?: boolean;
   validateOnChain?: boolean;
   staleTime?: number;
+  refetchInterval?: number | false;
   context?: 'dashboard-list' | 'detail-page' | 'critical-flow' | 'background-refetch';
 }
 
@@ -193,6 +200,7 @@ export const useEscrowsByRoleQuery = ({
   enabled = true,
   validateOnChain,
   staleTime,
+  refetchInterval,
   context = 'dashboard-list',
 }: UseEscrowsByRoleQueryParams) => {
   const { getEscrowsByRole } = useGetEscrowsFromIndexerByRole();
@@ -210,6 +218,8 @@ export const useEscrowsByRoleQuery = ({
   const resolvedStaleTime =
     staleTime !== undefined
       ? staleTime
+      : context === 'dashboard-list' && isActive
+        ? STALE_TIME.ACTIVE_ESCROW_POLLING
       : STALE_TIME[
           context === 'critical-flow'
             ? 'CRITICAL_FLOW'
@@ -217,6 +227,15 @@ export const useEscrowsByRoleQuery = ({
               ? 'DETAIL_PAGE'
               : 'DASHBOARD_LIST'
         ];
+
+  const resolvedRefetchInterval =
+    refetchInterval !== undefined
+      ? refetchInterval
+      : context === 'dashboard-list' &&
+          isActive &&
+          resolvedValidateOnChain === VALIDATE_ON_CHAIN.BACKGROUND_REFETCH
+        ? REFETCH_INTERVAL.ACTIVE_ESCROW_POLLING
+        : false;
 
   return useQuery({
     queryKey: [
@@ -315,6 +334,8 @@ export const useEscrowsByRoleQuery = ({
     },
     enabled: enabled && !!roleAddress && !!role && !!apiKey,
     staleTime: resolvedStaleTime,
+    refetchInterval: resolvedRefetchInterval,
+    refetchIntervalInBackground: false,
     retry: false,
   });
 };
@@ -350,6 +371,7 @@ export const useEscrowsBySignerQuery = ({
   enabled = true,
   validateOnChain,
   staleTime,
+  refetchInterval,
   context = 'dashboard-list',
 }: UseEscrowsBySignerQueryParams) => {
   const { getEscrowsBySigner } = useGetEscrowsFromIndexerBySigner();
@@ -367,6 +389,8 @@ export const useEscrowsBySignerQuery = ({
   const resolvedStaleTime =
     staleTime !== undefined
       ? staleTime
+      : context === 'dashboard-list' && isActive
+        ? STALE_TIME.ACTIVE_ESCROW_POLLING
       : STALE_TIME[
           context === 'critical-flow'
             ? 'CRITICAL_FLOW'
@@ -374,6 +398,15 @@ export const useEscrowsBySignerQuery = ({
               ? 'DETAIL_PAGE'
               : 'DASHBOARD_LIST'
         ];
+
+  const resolvedRefetchInterval =
+    refetchInterval !== undefined
+      ? refetchInterval
+      : context === 'dashboard-list' &&
+          isActive &&
+          resolvedValidateOnChain === VALIDATE_ON_CHAIN.BACKGROUND_REFETCH
+        ? REFETCH_INTERVAL.ACTIVE_ESCROW_POLLING
+        : false;
 
   return useQuery({
     queryKey: [
@@ -470,6 +503,8 @@ export const useEscrowsBySignerQuery = ({
     },
     enabled: enabled && !!signer && !!apiKey,
     staleTime: resolvedStaleTime,
+    refetchInterval: resolvedRefetchInterval,
+    refetchIntervalInBackground: false,
     retry: false,
   });
 };


### PR DESCRIPTION
closes #108 
### Motivation
- Dashboard escrow state was stale (5 minutes) which stalled active P2P trades because participants didn't see counterparty actions immediately.
- Supabase Realtime cannot be used yet (blocked by #102), so a polling-based minimum viable solution is required.
- Polling must be implemented carefully to avoid hitting TrustlessWork (TLW) rate limits by not validating on-chain during background refetches (see issue #107).

### Description
- Added `ACTIVE_ESCROW_POLLING` (15s) and `REFETCH_INTERVAL.ACTIVE_ESCROW_POLLING` (30s) constants to keep active dashboard escrows fresh in `apps/web/hooks/use-escrows.ts`.
- Extended `UseEscrowsByRoleQueryParams` and `UseEscrowsBySignerQueryParams` with an optional `refetchInterval` parameter and resolved sensible defaults when not provided.
- Implemented logic to default `staleTime` to 15s and enable a 30s `refetchInterval` only for active `dashboard-list` queries when `validateOnChain` resolves to `false`, and set `refetchIntervalInBackground: false` to avoid background-tab polling.
- Preserved existing rate-limit handling and exponential backoff, and kept `validateOnChain` configurable so on-chain validation remains avoided during background polling.

### Testing
- Ran `npm run -s type-check` across the workspace and the type check completed successfully.

------


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Active escrows displayed on the dashboard now sync at more frequent intervals, providing improved real-time visibility of status updates and changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->