### PR TITLE
feat: store and display merchant rejection reason to applicants

### DIFF
--- a/apps/web/app/dashboard/merchant/page.tsx
+++ b/apps/web/app/dashboard/merchant/page.tsx
@@ -42,8 +42,22 @@ export default function MerchantDashboardPage() {
     );
   }
 
+  const isRejectedOrRevoked =
+    me.data?.verification_status === 'rejected' ||
+    me.data?.verification_status === 'revoked';
+
   return (
     <div className="mx-auto space-y-8 p-4 sm:p-6">
+      {isRejectedOrRevoked && me.data?.status_message && (
+        <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-sm">
+          <p className="font-semibold text-destructive mb-1">
+            {me.data.verification_status === 'rejected'
+              ? 'Application Rejected'
+              : 'Verification Revoked'}
+          </p>
+          <p className="text-destructive/90">{me.data.status_message}</p>
+        </div>
+      )}
       <div className="flex items-center justify-between">
         <div className="text-4xl font-bold text-foreground">Merchant</div>
         <div className="flex gap-2">

--- a/apps/web/components/admin/MerchantApplicationModal.tsx
+++ b/apps/web/components/admin/MerchantApplicationModal.tsx
@@ -20,9 +20,12 @@ import {
   Dialog,
   DialogContent,
   DialogDescription,
+  DialogFooter,
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import { Textarea } from '@/components/ui/textarea';
+import { Label } from '@/components/ui/label';
 import {
   useApproveMerchant,
   useRejectMerchant,
@@ -30,6 +33,8 @@ import {
 } from '@/hooks/use-admin';
 import { toast } from 'sonner';
 import type { MerchantApplication } from '@/lib/types/admin';
+
+type PendingAction = 'reject' | 'revoke' | null;
 
 interface MerchantApplicationModalProps {
   application: MerchantApplication;
@@ -52,6 +57,8 @@ export function MerchantApplicationModal({
   onClose,
 }: MerchantApplicationModalProps) {
   const [isOpen, setIsOpen] = useState(true);
+  const [pendingAction, setPendingAction] = useState<PendingAction>(null);
+  const [statusMessage, setStatusMessage] = useState('');
   const approveMutation = useApproveMerchant();
   const rejectMutation = useRejectMerchant();
   const revokeMutation = useRevokeMerchant();
@@ -72,24 +79,21 @@ export function MerchantApplicationModal({
     }
   };
 
-  const handleReject = async () => {
+  const handleConfirmAction = async () => {
+    if (!pendingAction || !statusMessage.trim()) return;
     try {
-      await rejectMutation.mutateAsync({ id: application.id });
-      toast.success('Merchant application rejected');
+      if (pendingAction === 'reject') {
+        await rejectMutation.mutateAsync({ id: application.id, reason: statusMessage.trim() });
+        toast.success('Merchant application rejected');
+      } else {
+        await revokeMutation.mutateAsync({ id: application.id, reason: statusMessage.trim() });
+        toast.success('Merchant verification revoked');
+      }
+      setPendingAction(null);
+      setStatusMessage('');
       handleClose();
     } catch (error) {
-      toast.error('Failed to reject merchant application');
-      console.error(error);
-    }
-  };
-
-  const handleRevoke = async () => {
-    try {
-      await revokeMutation.mutateAsync({ id: application.id });
-      toast.success('Merchant verification revoked');
-      handleClose();
-    } catch (error) {
-      toast.error('Failed to revoke merchant verification');
+      toast.error(pendingAction === 'reject' ? 'Failed to reject merchant application' : 'Failed to revoke merchant verification');
       console.error(error);
     }
   };
@@ -99,7 +103,56 @@ export function MerchantApplicationModal({
     rejectMutation.isPending ||
     revokeMutation.isPending;
 
+  const isConfirming = rejectMutation.isPending || revokeMutation.isPending;
+
   return (
+    <>
+    <Dialog
+      open={pendingAction !== null}
+      onOpenChange={(open) => { if (!open) { setPendingAction(null); setStatusMessage(''); } }}
+    >
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>
+            {pendingAction === 'reject' ? 'Reject Application' : 'Revoke Verification'}
+          </DialogTitle>
+          <DialogDescription>
+            {pendingAction === 'reject'
+              ? 'Provide a reason so the merchant knows what to improve.'
+              : 'Provide a reason for revoking this merchant\'s verification.'}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-2 py-2">
+          <Label htmlFor="status-message">
+            Reason <span className="text-destructive">*</span>
+          </Label>
+          <Textarea
+            id="status-message"
+            placeholder="e.g. Your profile bio is incomplete. Please add more details about your trading experience."
+            value={statusMessage}
+            onChange={(e) => setStatusMessage(e.target.value)}
+            rows={4}
+          />
+        </div>
+        <DialogFooter>
+          <Button
+            variant="ghost"
+            onClick={() => { setPendingAction(null); setStatusMessage(''); }}
+            disabled={isConfirming}
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={handleConfirmAction}
+            disabled={!statusMessage.trim() || isConfirming}
+          >
+            {isConfirming ? 'Processing...' : pendingAction === 'reject' ? 'Reject' : 'Revoke'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+
     <Dialog open={isOpen} onOpenChange={handleClose}>
       <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
         <DialogHeader>
@@ -270,43 +323,25 @@ export function MerchantApplicationModal({
                   )}
                 </Button>
                 <Button
-                  onClick={handleReject}
+                  onClick={() => setPendingAction('reject')}
                   disabled={isLoading}
                   variant="destructive"
                   className="flex-1"
                 >
-                  {rejectMutation.isPending ? (
-                    <>
-                      <span className="animate-spin mr-2">⏳</span>
-                      Rejecting...
-                    </>
-                  ) : (
-                    <>
-                      <XCircle className="w-4 h-4 mr-2" />
-                      Reject
-                    </>
-                  )}
+                  <XCircle className="w-4 h-4 mr-2" />
+                  Reject
                 </Button>
               </>
             )}
             {application.verification_status === 'verified' && (
               <Button
-                onClick={handleRevoke}
+                onClick={() => setPendingAction('revoke')}
                 disabled={isLoading}
                 variant="destructive"
                 className="flex-1"
               >
-                {revokeMutation.isPending ? (
-                  <>
-                    <span className="animate-spin mr-2">⏳</span>
-                    Revoking...
-                  </>
-                ) : (
-                  <>
-                    <Ban className="w-4 h-4 mr-2" />
-                    Revoke Verification
-                  </>
-                )}
+                <Ban className="w-4 h-4 mr-2" />
+                Revoke Verification
               </Button>
             )}
             {(application.verification_status === 'rejected' ||
@@ -333,5 +368,6 @@ export function MerchantApplicationModal({
         </div>
       </DialogContent>
     </Dialog>
+    </>
   );
 }

--- a/apps/web/components/admin/MerchantApplications.tsx
+++ b/apps/web/components/admin/MerchantApplications.tsx
@@ -4,6 +4,16 @@ import { useState } from 'react';
 import { Loader2, CheckCircle, XCircle, Eye } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Textarea } from '@/components/ui/textarea';
+import { Label } from '@/components/ui/label';
 import { MerchantApplicationModal } from './MerchantApplicationModal';
 import { MerchantApplicationFilters } from './MerchantApplicationFilters';
 import {
@@ -32,6 +42,8 @@ export function MerchantApplications() {
   const [activeFilter, setActiveFilter] = useState('pending');
   const [selectedApplication, setSelectedApplication] =
     useState<MerchantApplication | null>(null);
+  const [rejectTarget, setRejectTarget] = useState<MerchantApplication | null>(null);
+  const [rejectMessage, setRejectMessage] = useState('');
 
   const {
     data: applications,
@@ -52,10 +64,13 @@ export function MerchantApplications() {
     }
   };
 
-  const handleReject = async (application: MerchantApplication) => {
+  const handleConfirmReject = async () => {
+    if (!rejectTarget || !rejectMessage.trim()) return;
     try {
-      await rejectMutation.mutateAsync({ id: application.id });
+      await rejectMutation.mutateAsync({ id: rejectTarget.id, reason: rejectMessage.trim() });
       toast.success('Merchant application rejected');
+      setRejectTarget(null);
+      setRejectMessage('');
     } catch {
       toast.error('Failed to reject merchant application');
     }
@@ -169,7 +184,7 @@ export function MerchantApplications() {
                           <Button
                             size="sm"
                             variant="destructive"
-                            onClick={() => handleReject(application)}
+                            onClick={() => setRejectTarget(application)}
                             disabled={
                               approveMutation.isPending ||
                               rejectMutation.isPending
@@ -195,6 +210,48 @@ export function MerchantApplications() {
           onClose={() => setSelectedApplication(null)}
         />
       )}
+
+      <Dialog
+        open={rejectTarget !== null}
+        onOpenChange={(open) => { if (!open) { setRejectTarget(null); setRejectMessage(''); } }}
+      >
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>Reject Application</DialogTitle>
+            <DialogDescription>
+              Provide a reason so the merchant knows what to improve.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2 py-2">
+            <Label htmlFor="reject-message">
+              Reason <span className="text-destructive">*</span>
+            </Label>
+            <Textarea
+              id="reject-message"
+              placeholder="e.g. Your profile bio is incomplete. Please add more details about your trading experience."
+              value={rejectMessage}
+              onChange={(e) => setRejectMessage(e.target.value)}
+              rows={4}
+            />
+          </div>
+          <DialogFooter>
+            <Button
+              variant="ghost"
+              onClick={() => { setRejectTarget(null); setRejectMessage(''); }}
+              disabled={rejectMutation.isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={handleConfirmReject}
+              disabled={!rejectMessage.trim() || rejectMutation.isPending}
+            >
+              {rejectMutation.isPending ? 'Rejecting...' : 'Reject'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/apps/web/lib/services/admin.ts
+++ b/apps/web/lib/services/admin.ts
@@ -254,15 +254,15 @@ export class AdminService {
   }
 
   static async approveMerchant(
-    id: string, 
-    auditContext?: { 
-      adminUserId: string; 
-      ipAddress?: string; 
-      userAgent?: string; 
-      reason?: string; 
+    id: string,
+    auditContext?: {
+      adminUserId: string;
+      ipAddress?: string;
+      userAgent?: string;
+      reason?: string;
     }
   ) {
-    const result = await AdminService.updateMerchantStatus(id, 'verified');
+    const result = await AdminService.updateMerchantStatus(id, 'verified', auditContext?.reason);
     
     // Log the approval
     if (auditContext?.adminUserId) {
@@ -285,15 +285,15 @@ export class AdminService {
   }
 
   static async rejectMerchant(
-    id: string, 
-    auditContext?: { 
-      adminUserId: string; 
-      ipAddress?: string; 
-      userAgent?: string; 
-      reason?: string; 
+    id: string,
+    auditContext?: {
+      adminUserId: string;
+      ipAddress?: string;
+      userAgent?: string;
+      reason?: string;
     }
   ) {
-    const result = await AdminService.updateMerchantStatus(id, 'rejected');
+    const result = await AdminService.updateMerchantStatus(id, 'rejected', auditContext?.reason);
     
     // Log the rejection
     if (auditContext?.adminUserId) {
@@ -318,15 +318,19 @@ export class AdminService {
   /** Unified method to approve or reject a merchant application */
   static async updateMerchantStatus(
     merchantId: string,
-    status: 'verified' | 'rejected'
+    status: 'verified' | 'rejected',
+    statusMessage?: string
   ) {
     const supabase = createAdminClient();
+    const now = new Date().toISOString();
     const { data, error } = await supabase
       .from('merchants')
       .update({
         verification_status: status,
         is_public: status === 'verified',
-        updated_at: new Date().toISOString(),
+        status_message: statusMessage ?? null,
+        status_updated_at: now,
+        updated_at: now,
       })
       .eq('id', merchantId)
       .select()
@@ -337,21 +341,24 @@ export class AdminService {
   }
 
   static async revokeMerchant(
-    id: string, 
-    auditContext?: { 
-      adminUserId: string; 
-      ipAddress?: string; 
-      userAgent?: string; 
-      reason?: string; 
+    id: string,
+    auditContext?: {
+      adminUserId: string;
+      ipAddress?: string;
+      userAgent?: string;
+      reason?: string;
     }
   ) {
     const supabase = createAdminClient();
+    const now = new Date().toISOString();
     const { data, error } = await supabase
       .from('merchants')
       .update({
         verification_status: 'revoked',
         is_public: false,
-        updated_at: new Date().toISOString(),
+        status_message: auditContext?.reason ?? null,
+        status_updated_at: now,
+        updated_at: now,
       })
       .eq('id', id)
       .select()

--- a/apps/web/lib/types/admin.ts
+++ b/apps/web/lib/types/admin.ts
@@ -46,6 +46,8 @@ export interface MerchantApplication {
   rating: number;
   total_trades: number;
   volume_traded: number;
+  status_message?: string;
+  status_updated_at?: string;
   created_at: string;
   updated_at: string;
   user?: {

--- a/apps/web/lib/types/merchant.ts
+++ b/apps/web/lib/types/merchant.ts
@@ -19,6 +19,8 @@ export type Merchant = {
   rating: number;
   total_trades: number;
   volume_traded: number; // 30d or lifetime; we’ll show clearly which
+  status_message?: string;
+  status_updated_at?: string;
 };
 
 export type MerchantBadge = {

--- a/supabase/migrations/20260329000006_add_status_message_to_merchants.sql
+++ b/supabase/migrations/20260329000006_add_status_message_to_merchants.sql
@@ -1,0 +1,3 @@
+ALTER TABLE merchants
+  ADD COLUMN IF NOT EXISTS status_message TEXT,
+  ADD COLUMN IF NOT EXISTS status_updated_at TIMESTAMPTZ;


### PR DESCRIPTION
  Adds status_message and status_updated_at columns to the merchants table so admins can communicate why an application
  was rejected or revoked, and merchants can see the reason directly in their dashboard.

  Changes:
  - supabase/migrations/20260329000006_add_status_message_to_merchants.sql — adds status_message TEXT and
  status_updated_at TIMESTAMPTZ to merchants table
  - apps/web/app/api/admin/merchants/[id]/route.ts — accepts reason in request body and passes it through auditContext
  - lib/services/admin.ts — updateMerchantStatus() persists status_message and status_updated_at on every status
  transition
  - components/admin/MerchantApplications.tsx — rejection dialog with required reason textarea; confirm button disabled
  until reason is provided
  - components/admin/MerchantApplicationModal.tsx — reject and revoke dialogs both require a reason before confirming
  - apps/web/app/dashboard/merchant/page.tsx — displays status_message in a destructive alert when verification_status
  is rejected or revoked

  Closes #116 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Merchants now receive detailed status notifications on their dashboard when applications are rejected or verifications are revoked, with reasons provided by administrators
  * Administrators must provide a reason when rejecting or revoking merchant applications through a confirmation dialog
  * System now tracks timestamps for all application status changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->