### PR TITLE
fix: enforce ownership in receipts storage RLS policies

### DIFF
--- a/apps/web/lib/services/receipts.ts
+++ b/apps/web/lib/services/receipts.ts
@@ -10,6 +10,7 @@ const ACCEPTED_TYPES = [
 ];
 
 export async function uploadReceipt(
+  userId: string,
   escrowId: string,
   file: File
 ): Promise<string> {
@@ -22,7 +23,7 @@ export async function uploadReceipt(
   }
 
   const ext = file.name.split('.').pop() || 'bin';
-  const path = `${escrowId}/${Date.now()}_${crypto.randomUUID()}.${ext}`;
+  const path = `${userId}/${escrowId}/${Date.now()}_${crypto.randomUUID()}.${ext}`;
 
   const { error } = await supabase.storage
     .from(RECEIPTS_BUCKET)

--- a/supabase/migrations/20260329000007_fix_receipts_rls_ownership.sql
+++ b/supabase/migrations/20260329000007_fix_receipts_rls_ownership.sql
@@ -1,0 +1,24 @@
+-- Fix receipts bucket RLS: enforce ownership on INSERT and DELETE, remove UPDATE
+-- Path structure changed to: {user_id}/{escrow_id}/{timestamp}_{uuid}.{ext}
+-- This allows ownership to be derived from the first path segment via foldername()
+
+-- Tighten INSERT: user can only upload to their own folder
+DROP POLICY IF EXISTS "Users can upload receipts" ON storage.objects;
+CREATE POLICY "Users can upload receipts"
+ON storage.objects FOR INSERT TO authenticated
+WITH CHECK (
+  bucket_id = 'receipts' AND
+  (storage.foldername(name))[1] = auth.uid()::text
+);
+
+-- Remove UPDATE: receipts are immutable once uploaded
+DROP POLICY IF EXISTS "Users can update receipts" ON storage.objects;
+
+-- Tighten DELETE: only the uploader can delete their own receipts
+DROP POLICY IF EXISTS "Users can delete receipts" ON storage.objects;
+CREATE POLICY "Users can delete own receipts"
+ON storage.objects FOR DELETE TO authenticated
+USING (
+  bucket_id = 'receipts' AND
+  (storage.foldername(name))[1] = auth.uid()::text
+);


### PR DESCRIPTION
Closes #110 

## Summary

  - Changed upload path structure from `{escrowId}/...` to `{userId}/{escrowId}/...` to enable ownership enforcement via
   path segments
  - Removed `UPDATE` policy on `storage.objects` for the `receipts` bucket — receipts are immutable once uploaded
  - Replaced `DELETE` policy to restrict deletion to the file owner only (`foldername(name)[1] = auth.uid()`)
  - Tightened `INSERT` policy to prevent users from uploading into another user's folder

  ## Notes

  While investigating this fix, a separate bug was found: `uploadReceipt` in `apps/web/lib/services/receipts.ts` has no
  callers — the "Report Payment" flow currently hardcodes `evidence: ''` and the `ReceiptDialog` component exists but is
   not wired to the service. This means the receipt upload feature is not yet functional end-to-end. This is out of
  scope for #110 and should be tracked as a separate issue.

  ## Test plan

  - [ ] Authenticated user A uploads a receipt → file stored under `{userA_id}/{escrowId}/...`
  - [ ] Authenticated user B attempts to DELETE user A's receipt → blocked by RLS
  - [ ] Authenticated user B attempts to UPDATE user A's receipt → blocked (policy removed)
  - [ ] Authenticated user A can DELETE their own receipt
  - [ ] Unauthenticated user can read receipts publicly (SELECT policy unchanged)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed receipt storage structure to properly associate uploads with individual users
  * Enhanced security policies to prevent unauthorized access to receipts
  * Receipts are now immutable after upload for data integrity
  * Users can only delete their own receipts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->