### PR TITLE
docs(web): document backend integration env vars

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -60,6 +60,20 @@ NEXT_PUBLIC_ENV=development
 
 
 # -----------------------------------------------------------------------------
+# Backend (NestJS) integration
+# Server-side only — these are NOT exposed to the browser (no NEXT_PUBLIC_ prefix).
+# Used by apps/web to call the apps/backend service (see apps/backend/README.md).
+# -----------------------------------------------------------------------------
+
+# Base URL where the NestJS backend is reachable (default local port 3001)
+BACKEND_URL=http://localhost:3001
+
+# Shared service secret for web→backend calls. MUST match apps/backend/.env
+# INTERNAL_API_KEY. Generate one with: openssl rand -hex 32
+INTERNAL_API_KEY=<generate a long random string; must match apps/backend>
+
+
+# -----------------------------------------------------------------------------
 # Optional
 # The following variables are optional. The app uses defaults if they are unset.
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds a **Backend (NestJS) integration** section to `apps/web/.env.example` so the web app's env template documents the server-side variables needed to call `apps/backend` (introduced in #135):

- `BACKEND_URL` — base URL where the NestJS backend is reachable (default `http://localhost:3001`).
- `INTERNAL_API_KEY` — shared service secret for web→backend calls; must match `apps/backend/.env`'s `INTERNAL_API_KEY` (the `x-internal-key` the backend guard validates).

Both are server-side only (no `NEXT_PUBLIC_` prefix). This is template/documentation only — no code changes and no secrets committed (placeholders only). It prepares the web side of the service-to-service auth mechanism that phase 2 (#136) will start consuming.

## Test plan

- `cp apps/web/.env.example apps/web/.env` and fill `INTERNAL_API_KEY` with the same value as `apps/backend/.env` (`openssl rand -hex 32`).
- No build impact (template file only); `npm run type-check` / `build` unaffected.
