### PR TITLE
feat: scheduled cleanup & SLA jobs / cron (#137)

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -25,3 +25,12 @@ REPUTATION_RECENCY_DAYS=90
 REPUTATION_DECAY=0.9
 REPUTATION_VOLUME_WEIGHT=0.05
 REPUTATION_VOLUME_SAT=10000
+
+# Scheduled jobs (cron) — all optional with defaults
+CRON_ENABLED=true
+# Nightly stats reconcile (cron expression)
+RECONCILE_CRON=0 3 * * *
+# Dispute SLA scan (cron expression)
+DISPUTE_SLA_CRON=0 * * * *
+# A dispute open longer than this many hours is "overdue"
+DISPUTE_SLA_HOURS=48

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -20,6 +20,7 @@
     "@nestjs/config": "^4.0.0",
     "@nestjs/core": "^11.0.0",
     "@nestjs/platform-express": "^11.0.0",
+    "@nestjs/schedule": "^5.0.0",
     "@nestjs/swagger": "^11.0.0",
     "@nestjs/terminus": "^11.0.0",
     "@nestjs/throttler": "^6.0.0",

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -5,6 +5,7 @@ import { PlatformModule } from '@domains/platform/platform.module';
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { APP_GUARD } from '@nestjs/core';
+import { ScheduleModule } from '@nestjs/schedule';
 import { ThrottlerGuard, ThrottlerModule } from '@nestjs/throttler';
 import type { Request } from 'express';
 import { LoggerModule } from 'nestjs-pino';
@@ -15,6 +16,7 @@ import { LoggerModule } from 'nestjs-pino';
       isGlobal: true,
       validationSchema: envValidationSchema,
     }),
+    ScheduleModule.forRoot(),
     LoggerModule.forRoot({
       pinoHttp: {
         customProps: (req) => ({

--- a/apps/backend/src/config/env.validation.ts
+++ b/apps/backend/src/config/env.validation.ts
@@ -18,4 +18,8 @@ export const envValidationSchema = Joi.object({
   REPUTATION_DECAY: Joi.number().min(0).max(1).default(0.9),
   REPUTATION_VOLUME_WEIGHT: Joi.number().min(0).max(1).default(0.05),
   REPUTATION_VOLUME_SAT: Joi.number().positive().default(10000),
+  CRON_ENABLED: Joi.boolean().default(true),
+  RECONCILE_CRON: Joi.string().default('0 3 * * *'),
+  DISPUTE_SLA_CRON: Joi.string().default('0 * * * *'),
+  DISPUTE_SLA_HOURS: Joi.number().positive().default(48),
 });

--- a/apps/backend/src/domains/platform/disputes/disputes.module.ts
+++ b/apps/backend/src/domains/platform/disputes/disputes.module.ts
@@ -1,0 +1,8 @@
+import { DisputesService } from '@domains/platform/disputes/disputes.service';
+import { Module } from '@nestjs/common';
+
+@Module({
+  providers: [DisputesService],
+  exports: [DisputesService],
+})
+export class DisputesModule {}

--- a/apps/backend/src/domains/platform/disputes/disputes.service.spec.ts
+++ b/apps/backend/src/domains/platform/disputes/disputes.service.spec.ts
@@ -1,0 +1,72 @@
+import {
+  type DisputeRow,
+  selectOverdue,
+} from '@domains/platform/disputes/disputes.service';
+
+const NOW = Date.parse('2026-06-26T00:00:00Z');
+const H = 3_600_000;
+
+function row(
+  hoursAgo: number,
+  status: string,
+  overrides: Partial<DisputeRow> = {}
+): DisputeRow {
+  return {
+    created_at: new Date(NOW - hoursAgo * H).toISOString(),
+    trade_chats: {
+      escrow_id: 'e1',
+      buyer_id: 'b1',
+      seller_id: 's1',
+      escrows: { status, engagement_id: 'eng1' },
+    },
+    ...overrides,
+  };
+}
+
+describe('selectOverdue', () => {
+  it('includes active disputes older than the threshold', () => {
+    const out = selectOverdue([row(50, 'active')], NOW, 48);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      escrowId: 'e1',
+      engagementId: 'eng1',
+      buyerId: 'b1',
+      sellerId: 's1',
+    });
+    expect(out[0].hoursOpen).toBeCloseTo(50, 5);
+  });
+
+  it('excludes disputes younger than the threshold', () => {
+    expect(selectOverdue([row(10, 'active')], NOW, 48)).toHaveLength(0);
+  });
+
+  it('excludes resolved/cancelled/completed disputes regardless of age', () => {
+    const rows = [
+      row(100, 'resolved'),
+      row(100, 'cancelled'),
+      row(100, 'completed'),
+    ];
+    expect(selectOverdue(rows, NOW, 48)).toHaveLength(0);
+  });
+
+  it('skips rows with no chat or no escrow', () => {
+    const noChat: DisputeRow = {
+      created_at: new Date(NOW - 100 * H).toISOString(),
+      trade_chats: null,
+    };
+    const noEscrow = row(100, 'active', {
+      trade_chats: {
+        escrow_id: 'e1',
+        buyer_id: 'b1',
+        seller_id: 's1',
+        escrows: null,
+      },
+    });
+    expect(selectOverdue([noChat, noEscrow], NOW, 48)).toHaveLength(0);
+  });
+
+  it('skips rows with an unparseable timestamp', () => {
+    const bad = row(100, 'active', { created_at: 'not-a-date' });
+    expect(selectOverdue([bad], NOW, 48)).toHaveLength(0);
+  });
+});

--- a/apps/backend/src/domains/platform/disputes/disputes.service.ts
+++ b/apps/backend/src/domains/platform/disputes/disputes.service.ts
@@ -1,0 +1,87 @@
+// biome-ignore lint/style/useImportType: required for NestJS dependency injection
+import { SupabaseService } from '@core/supabase/supabase.service';
+import { Injectable } from '@nestjs/common';
+
+export interface DisputeRow {
+  created_at: string;
+  trade_chats: {
+    escrow_id: string | null;
+    buyer_id: string | null;
+    seller_id: string | null;
+    escrows: { status: string; engagement_id: string } | null;
+  } | null;
+}
+
+export interface OverdueDispute {
+  escrowId: string;
+  engagementId: string;
+  buyerId: string | null;
+  sellerId: string | null;
+  disputeRaisedAt: string;
+  hoursOpen: number;
+}
+
+const HOUR_MS = 3_600_000;
+
+export function selectOverdue(
+  rows: DisputeRow[],
+  now: number,
+  thresholdHours: number
+): OverdueDispute[] {
+  const out: OverdueDispute[] = [];
+  for (const r of rows) {
+    const chat = r.trade_chats;
+    const escrow = chat?.escrows;
+    if (!chat || !escrow || !chat.escrow_id) {
+      continue;
+    }
+    if (escrow.status !== 'active') {
+      continue; // resolved / cancelled / completed = not an open dispute
+    }
+    const raisedMs = Date.parse(r.created_at);
+    if (Number.isNaN(raisedMs)) {
+      continue;
+    }
+    const hoursOpen = (now - raisedMs) / HOUR_MS;
+    if (hoursOpen <= thresholdHours) {
+      continue;
+    }
+    out.push({
+      escrowId: chat.escrow_id,
+      engagementId: escrow.engagement_id,
+      buyerId: chat.buyer_id,
+      sellerId: chat.seller_id,
+      disputeRaisedAt: r.created_at,
+      hoursOpen: Math.round(hoursOpen * 100) / 100,
+    });
+  }
+  return out;
+}
+
+@Injectable()
+export class DisputesService {
+  constructor(private readonly supabase: SupabaseService) {}
+
+  async findOverdueDisputes(
+    now: number,
+    thresholdHours: number
+  ): Promise<OverdueDispute[]> {
+    const cutoffIso = new Date(now - thresholdHours * HOUR_MS).toISOString();
+    const { data, error } = await this.supabase.client
+      .from('trade_messages')
+      .select(
+        'created_at, metadata, trade_chats!inner(escrow_id, buyer_id, seller_id, escrows!inner(status, engagement_id))'
+      )
+      .eq('message_type', 'system')
+      .eq('metadata->>event', 'dispute_raised')
+      .lte('created_at', cutoffIso);
+    if (error) {
+      throw new Error(`Failed to load disputes: ${error.message}`);
+    }
+    return selectOverdue(
+      (data ?? []) as unknown as DisputeRow[],
+      now,
+      thresholdHours
+    );
+  }
+}

--- a/apps/backend/src/domains/platform/jobs/dispute-sla.cron.spec.ts
+++ b/apps/backend/src/domains/platform/jobs/dispute-sla.cron.spec.ts
@@ -1,0 +1,58 @@
+import type {
+  DisputesService,
+  OverdueDispute,
+} from '@domains/platform/disputes/disputes.service';
+import { DisputeSlaCron } from '@domains/platform/jobs/dispute-sla.cron';
+import { Logger } from '@nestjs/common';
+import type { ConfigService } from '@nestjs/config';
+import type { SchedulerRegistry } from '@nestjs/schedule';
+
+describe('DisputeSlaCron.run', () => {
+  it('logs a breach per overdue dispute and a summary count', async () => {
+    const overdue: OverdueDispute[] = [
+      {
+        escrowId: 'e1',
+        engagementId: 'eng1',
+        buyerId: 'b1',
+        sellerId: 's1',
+        disputeRaisedAt: 'x',
+        hoursOpen: 50,
+      },
+      {
+        escrowId: 'e2',
+        engagementId: 'eng2',
+        buyerId: 'b2',
+        sellerId: 's2',
+        disputeRaisedAt: 'y',
+        hoursOpen: 72,
+      },
+    ];
+    const config = {
+      get: <T>(_k: string, d?: T) => d,
+    } as unknown as ConfigService;
+    const scheduler = {} as unknown as SchedulerRegistry;
+    const disputes = {
+      findOverdueDisputes: jest.fn().mockResolvedValue(overdue),
+    } as unknown as DisputesService;
+
+    const warn = jest
+      .spyOn(Logger.prototype, 'warn')
+      .mockImplementation(() => undefined);
+    const log = jest
+      .spyOn(Logger.prototype, 'log')
+      .mockImplementation(() => undefined);
+
+    const cron = new DisputeSlaCron(config, scheduler, disputes);
+    await cron.run();
+
+    expect(disputes.findOverdueDisputes).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledTimes(2);
+    expect(warn.mock.calls[0][0]).toContain('dispute_sla_breach');
+    expect(
+      log.mock.calls.some((c) => String(c[0]).includes('overdueCount=2'))
+    ).toBe(true);
+
+    warn.mockRestore();
+    log.mockRestore();
+  });
+});

--- a/apps/backend/src/domains/platform/jobs/dispute-sla.cron.ts
+++ b/apps/backend/src/domains/platform/jobs/dispute-sla.cron.ts
@@ -1,0 +1,62 @@
+// biome-ignore lint/style/useImportType: required for NestJS dependency injection
+import { DisputesService } from '@domains/platform/disputes/disputes.service';
+import { Injectable, Logger, type OnModuleInit } from '@nestjs/common';
+// biome-ignore lint/style/useImportType: required for NestJS dependency injection
+import { ConfigService } from '@nestjs/config';
+// biome-ignore lint/style/useImportType: required for NestJS dependency injection
+import { SchedulerRegistry } from '@nestjs/schedule';
+import { CronJob } from 'cron';
+
+@Injectable()
+export class DisputeSlaCron implements OnModuleInit {
+  private readonly logger = new Logger(DisputeSlaCron.name);
+  private isRunning = false;
+
+  constructor(
+    private readonly config: ConfigService,
+    private readonly scheduler: SchedulerRegistry,
+    private readonly disputes: DisputesService
+  ) {}
+
+  onModuleInit(): void {
+    if (!this.config.get<boolean>('CRON_ENABLED', true)) {
+      this.logger.log('CRON_ENABLED=false → dispute-sla not scheduled');
+      return;
+    }
+    const expr = this.config.get<string>('DISPUTE_SLA_CRON', '0 * * * *');
+    const job = new CronJob(expr, () => {
+      void this.run();
+    });
+    this.scheduler.addCronJob('dispute-sla', job);
+    job.start();
+    this.logger.log(`dispute-sla scheduled: ${expr}`);
+  }
+
+  async run(): Promise<void> {
+    if (this.isRunning) {
+      this.logger.warn('dispute-sla already running; skipping tick');
+      return;
+    }
+    this.isRunning = true;
+    try {
+      const thresholdHours = this.config.get<number>('DISPUTE_SLA_HOURS', 48);
+      const overdue = await this.disputes.findOverdueDisputes(
+        Date.now(),
+        thresholdHours
+      );
+      for (const d of overdue) {
+        this.logger.warn(
+          `dispute_sla_breach escrowId=${d.escrowId} engagementId=${d.engagementId} ` +
+            `buyerId=${d.buyerId} sellerId=${d.sellerId} hoursOpen=${d.hoursOpen}`
+        );
+      }
+      this.logger.log(
+        `dispute-sla done thresholdHours=${thresholdHours} overdueCount=${overdue.length}`
+      );
+    } catch (err) {
+      this.logger.error(`dispute-sla failed: ${(err as Error).message}`);
+    } finally {
+      this.isRunning = false;
+    }
+  }
+}

--- a/apps/backend/src/domains/platform/jobs/jobs.module.ts
+++ b/apps/backend/src/domains/platform/jobs/jobs.module.ts
@@ -1,0 +1,11 @@
+import { DisputesModule } from '@domains/platform/disputes/disputes.module';
+import { DisputeSlaCron } from '@domains/platform/jobs/dispute-sla.cron';
+import { StatsReconcileCron } from '@domains/platform/jobs/stats-reconcile.cron';
+import { StatsModule } from '@domains/platform/stats/stats.module';
+import { Module } from '@nestjs/common';
+
+@Module({
+  imports: [StatsModule, DisputesModule],
+  providers: [StatsReconcileCron, DisputeSlaCron],
+})
+export class JobsModule {}

--- a/apps/backend/src/domains/platform/jobs/stats-reconcile.cron.ts
+++ b/apps/backend/src/domains/platform/jobs/stats-reconcile.cron.ts
@@ -1,0 +1,53 @@
+// biome-ignore lint/style/useImportType: required for NestJS dependency injection
+import { StatsService } from '@domains/platform/stats/stats.service';
+import { Injectable, Logger, type OnModuleInit } from '@nestjs/common';
+// biome-ignore lint/style/useImportType: required for NestJS dependency injection
+import { ConfigService } from '@nestjs/config';
+// biome-ignore lint/style/useImportType: required for NestJS dependency injection
+import { SchedulerRegistry } from '@nestjs/schedule';
+import { CronJob } from 'cron';
+
+@Injectable()
+export class StatsReconcileCron implements OnModuleInit {
+  private readonly logger = new Logger(StatsReconcileCron.name);
+  private isRunning = false;
+
+  constructor(
+    private readonly config: ConfigService,
+    private readonly scheduler: SchedulerRegistry,
+    private readonly stats: StatsService
+  ) {}
+
+  onModuleInit(): void {
+    if (!this.config.get<boolean>('CRON_ENABLED', true)) {
+      this.logger.log('CRON_ENABLED=false → stats-reconcile not scheduled');
+      return;
+    }
+    const expr = this.config.get<string>('RECONCILE_CRON', '0 3 * * *');
+    const job = new CronJob(expr, () => {
+      void this.run();
+    });
+    this.scheduler.addCronJob('stats-reconcile', job);
+    job.start();
+    this.logger.log(`stats-reconcile scheduled: ${expr}`);
+  }
+
+  async run(): Promise<void> {
+    if (this.isRunning) {
+      this.logger.warn('stats-reconcile already running; skipping tick');
+      return;
+    }
+    this.isRunning = true;
+    const start = Date.now();
+    try {
+      const result = await this.stats.recomputeAll();
+      this.logger.log(
+        `stats-reconcile done users=${result.users} durationMs=${Date.now() - start}`
+      );
+    } catch (err) {
+      this.logger.error(`stats-reconcile failed: ${(err as Error).message}`);
+    } finally {
+      this.isRunning = false;
+    }
+  }
+}

--- a/apps/backend/src/domains/platform/platform.module.ts
+++ b/apps/backend/src/domains/platform/platform.module.ts
@@ -1,7 +1,8 @@
+import { JobsModule } from '@domains/platform/jobs/jobs.module';
 import { StatsModule } from '@domains/platform/stats/stats.module';
 import { Module } from '@nestjs/common';
 
 @Module({
-  imports: [StatsModule],
+  imports: [StatsModule, JobsModule],
 })
 export class PlatformModule {}

--- a/docs/superpowers/plans/2026-06-26-backend-phase3-cron.md
+++ b/docs/superpowers/plans/2026-06-26-backend-phase3-cron.md
@@ -1,0 +1,542 @@
+# Backend Phase 3 — Cron Jobs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `@nestjs/schedule` cron infrastructure to `apps/backend` plus two scheduled jobs: a nightly stats reconcile (`StatsService.recomputeAll()`) and a dispute-SLA scanner that logs overdue disputes.
+
+**Architecture:** Two cron providers in `domains/platform/jobs` register their jobs via `SchedulerRegistry` in `onModuleInit` (so schedules come from env at runtime, which the `@Cron` decorator can't do). Each is overlap-guarded and never throws. The overdue-dispute selection is a pure, unit-tested function fed by a service query over existing data (no migration).
+
+**Tech Stack:** NestJS 11, `@nestjs/schedule` (+ `cron`), `@supabase/supabase-js` (service role), `@nestjs/config` (Joi), Jest.
+
+**Spec:** `docs/superpowers/specs/2026-06-26-backend-phase3-cron-design.md`
+**Branch:** `feat/137-cron-jobs` (stacked on `feat/136-stats-reputation`; depends on phase 2's `StatsService`).
+**Build hygiene:** `rm -rf apps/backend/dist apps/backend/*.tsbuildinfo` before any backend build. Run the backend from `apps/backend` (dotenv uses cwd).
+**DI footgun:** keep injected deps (`ConfigService`, `SchedulerRegistry`, `SupabaseService`, `StatsService`, `DisputesService`) as VALUE imports; add `// biome-ignore lint/style/useImportType: required for NestJS dependency injection` if Biome rewrites them. After `biome:fix`, grep to confirm. Pure-type imports (`OnModuleInit`, row interfaces) stay `import type`.
+
+---
+
+## File map
+
+| File | Responsibility |
+|---|---|
+| `apps/backend/package.json` (mod) | add `@nestjs/schedule` |
+| `apps/backend/src/config/env.validation.ts` (mod), `.env.example` (mod) | `CRON_*` / `DISPUTE_SLA_*` env (defaulted) |
+| `apps/backend/src/app.module.ts` (mod) | `ScheduleModule.forRoot()` |
+| `apps/backend/src/domains/platform/disputes/disputes.service.ts` | `selectOverdue` (pure) + `findOverdueDisputes` (query) |
+| `.../disputes/disputes.service.spec.ts` | overdue-selection unit tests |
+| `.../disputes/disputes.module.ts` | provides/exports `DisputesService` |
+| `.../jobs/stats-reconcile.cron.ts` | nightly reconcile cron |
+| `.../jobs/dispute-sla.cron.ts` | dispute SLA cron (logs breaches) |
+| `.../jobs/dispute-sla.cron.spec.ts` | `run()` emits alerts for overdue disputes |
+| `.../jobs/jobs.module.ts` | imports StatsModule + DisputesModule; declares the crons |
+| `apps/backend/src/domains/platform/platform.module.ts` (mod) | import `JobsModule` |
+
+---
+
+## Task 1: Cron infrastructure (schedule module + env)
+
+**Files:**
+- Modify: `apps/backend/package.json`, `apps/backend/src/app.module.ts`, `apps/backend/src/config/env.validation.ts`, `apps/backend/.env.example`
+
+- [ ] **Step 1: Add the dependency**
+
+In `apps/backend/package.json` `dependencies`, add `"@nestjs/schedule": "^4.1.0"`. (It bundles the `cron` package.)
+
+- [ ] **Step 2: Install**
+
+Run: `npm install` (root). If a peer conflict with `@nestjs/core@11` appears, use the `@nestjs/schedule` major compatible with Nest 11 (`^4` or `^5`) and report the choice.
+
+- [ ] **Step 3: Add cron env to `apps/backend/src/config/env.validation.ts`**
+
+Inside the `Joi.object({ ... })`, add:
+```ts
+  CRON_ENABLED: Joi.boolean().default(true),
+  RECONCILE_CRON: Joi.string().default('0 3 * * *'),
+  DISPUTE_SLA_CRON: Joi.string().default('0 * * * *'),
+  DISPUTE_SLA_HOURS: Joi.number().positive().default(48),
+```
+
+- [ ] **Step 4: Document them in `apps/backend/.env.example`**
+
+Append:
+```dotenv
+
+# Scheduled jobs (cron) — all optional with defaults
+CRON_ENABLED=true
+# Nightly stats reconcile (cron expression)
+RECONCILE_CRON=0 3 * * *
+# Dispute SLA scan (cron expression)
+DISPUTE_SLA_CRON=0 * * * *
+# A dispute open longer than this many hours is "overdue"
+DISPUTE_SLA_HOURS=48
+```
+
+- [ ] **Step 5: Register `ScheduleModule` in `apps/backend/src/app.module.ts`**
+
+Add `import { ScheduleModule } from '@nestjs/schedule';` and add `ScheduleModule.forRoot()` to the `imports` array (e.g. right after `ConfigModule.forRoot(...)`). Do not change anything else.
+
+- [ ] **Step 6: Build + boot smoke**
+
+Run: `rm -rf apps/backend/dist apps/backend/*.tsbuildinfo && (cd apps/backend && npm run build) && (cd apps/backend && node dist/main.js & sleep 2 ; curl -s -o /dev/null -w "%{http_code}\n" localhost:3001/health ; kill %1)`
+Expected: build OK; `/health` responds (200 or 503). App boots with ScheduleModule loaded.
+
+- [ ] **Step 7: Biome + type-check + commit**
+
+```bash
+cd apps/backend && npm run biome:fix && npm run biome:check && cd ../..
+npm run type-check
+git add apps/backend/package.json apps/backend/src/app.module.ts apps/backend/src/config/env.validation.ts apps/backend/.env.example package-lock.json
+git commit -m "feat(backend): add @nestjs/schedule cron infrastructure + env (#137)"
+```
+
+---
+
+## Task 2: DisputesService + overdue selection (TDD)
+
+**Files:**
+- Create: `apps/backend/src/domains/platform/disputes/disputes.service.ts`, `disputes.service.spec.ts`, `disputes.module.ts`
+
+- [ ] **Step 1: Write the failing test `disputes.service.spec.ts`**
+
+```ts
+import { selectOverdue, type DisputeRow } from '@domains/platform/disputes/disputes.service';
+
+const NOW = Date.parse('2026-06-26T00:00:00Z');
+const H = 3_600_000;
+
+function row(hoursAgo: number, status: string, overrides: Partial<DisputeRow> = {}): DisputeRow {
+  return {
+    created_at: new Date(NOW - hoursAgo * H).toISOString(),
+    trade_chats: {
+      escrow_id: 'e1',
+      buyer_id: 'b1',
+      seller_id: 's1',
+      escrows: { status, engagement_id: 'eng1' },
+    },
+    ...overrides,
+  };
+}
+
+describe('selectOverdue', () => {
+  it('includes active disputes older than the threshold', () => {
+    const out = selectOverdue([row(50, 'active')], NOW, 48);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ escrowId: 'e1', engagementId: 'eng1', buyerId: 'b1', sellerId: 's1' });
+    expect(out[0].hoursOpen).toBeCloseTo(50, 5);
+  });
+
+  it('excludes disputes younger than the threshold', () => {
+    expect(selectOverdue([row(10, 'active')], NOW, 48)).toHaveLength(0);
+  });
+
+  it('excludes resolved/cancelled/completed disputes regardless of age', () => {
+    const rows = [row(100, 'resolved'), row(100, 'cancelled'), row(100, 'completed')];
+    expect(selectOverdue(rows, NOW, 48)).toHaveLength(0);
+  });
+
+  it('skips rows with no chat or no escrow', () => {
+    const noChat: DisputeRow = { created_at: new Date(NOW - 100 * H).toISOString(), trade_chats: null };
+    const noEscrow = row(100, 'active', {
+      trade_chats: { escrow_id: 'e1', buyer_id: 'b1', seller_id: 's1', escrows: null },
+    });
+    expect(selectOverdue([noChat, noEscrow], NOW, 48)).toHaveLength(0);
+  });
+
+  it('skips rows with an unparseable timestamp', () => {
+    const bad = row(100, 'active', { created_at: 'not-a-date' });
+    expect(selectOverdue([bad], NOW, 48)).toHaveLength(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd apps/backend && npm test -- disputes.service`
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Implement `disputes.service.ts`**
+
+```ts
+import { Injectable } from '@nestjs/common';
+// biome-ignore lint/style/useImportType: required for NestJS dependency injection
+import { SupabaseService } from '@core/supabase/supabase.service';
+
+export interface DisputeRow {
+  created_at: string;
+  trade_chats: {
+    escrow_id: string | null;
+    buyer_id: string | null;
+    seller_id: string | null;
+    escrows: { status: string; engagement_id: string } | null;
+  } | null;
+}
+
+export interface OverdueDispute {
+  escrowId: string;
+  engagementId: string;
+  buyerId: string | null;
+  sellerId: string | null;
+  disputeRaisedAt: string;
+  hoursOpen: number;
+}
+
+const HOUR_MS = 3_600_000;
+
+export function selectOverdue(
+  rows: DisputeRow[],
+  now: number,
+  thresholdHours: number
+): OverdueDispute[] {
+  const out: OverdueDispute[] = [];
+  for (const r of rows) {
+    const chat = r.trade_chats;
+    const escrow = chat?.escrows;
+    if (!chat || !escrow || !chat.escrow_id) {
+      continue;
+    }
+    if (escrow.status !== 'active') {
+      continue; // resolved / cancelled / completed = not an open dispute
+    }
+    const raisedMs = Date.parse(r.created_at);
+    if (Number.isNaN(raisedMs)) {
+      continue;
+    }
+    const hoursOpen = (now - raisedMs) / HOUR_MS;
+    if (hoursOpen <= thresholdHours) {
+      continue;
+    }
+    out.push({
+      escrowId: chat.escrow_id,
+      engagementId: escrow.engagement_id,
+      buyerId: chat.buyer_id,
+      sellerId: chat.seller_id,
+      disputeRaisedAt: r.created_at,
+      hoursOpen: Math.round(hoursOpen * 100) / 100,
+    });
+  }
+  return out;
+}
+
+@Injectable()
+export class DisputesService {
+  constructor(private readonly supabase: SupabaseService) {}
+
+  async findOverdueDisputes(
+    now: number,
+    thresholdHours: number
+  ): Promise<OverdueDispute[]> {
+    const cutoffIso = new Date(now - thresholdHours * HOUR_MS).toISOString();
+    const { data, error } = await this.supabase.client
+      .from('trade_messages')
+      .select(
+        'created_at, metadata, trade_chats!inner(escrow_id, buyer_id, seller_id, escrows!inner(status, engagement_id))'
+      )
+      .eq('message_type', 'system')
+      .eq('metadata->>event', 'dispute_raised')
+      .lte('created_at', cutoffIso);
+    if (error) {
+      throw new Error(`Failed to load disputes: ${error.message}`);
+    }
+    return selectOverdue(
+      (data ?? []) as unknown as DisputeRow[],
+      now,
+      thresholdHours
+    );
+  }
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd apps/backend && npm test -- disputes.service`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Create `disputes.module.ts`**
+
+```ts
+import { Module } from '@nestjs/common';
+import { DisputesService } from '@domains/platform/disputes/disputes.service';
+
+@Module({
+  providers: [DisputesService],
+  exports: [DisputesService],
+})
+export class DisputesModule {}
+```
+
+- [ ] **Step 6: Biome + type-check + commit**
+
+```bash
+cd apps/backend && npm run biome:fix && npm run biome:check && cd ../..
+npm run type-check
+git add apps/backend/src/domains/platform/disputes
+git commit -m "feat(backend): add DisputesService + overdue-dispute selection + tests (#137)"
+```
+
+---
+
+## Task 3: Cron jobs (reconcile + dispute SLA) + wiring
+
+**Files:**
+- Create: `apps/backend/src/domains/platform/jobs/stats-reconcile.cron.ts`, `dispute-sla.cron.ts`, `dispute-sla.cron.spec.ts`, `jobs.module.ts`
+- Modify: `apps/backend/src/domains/platform/platform.module.ts`
+
+- [ ] **Step 1: Create `stats-reconcile.cron.ts`**
+
+```ts
+import { Injectable, Logger, type OnModuleInit } from '@nestjs/common';
+// biome-ignore lint/style/useImportType: required for NestJS dependency injection
+import { ConfigService } from '@nestjs/config';
+// biome-ignore lint/style/useImportType: required for NestJS dependency injection
+import { SchedulerRegistry } from '@nestjs/schedule';
+// biome-ignore lint/style/useImportType: required for NestJS dependency injection
+import { StatsService } from '@domains/platform/stats/stats.service';
+import { CronJob } from 'cron';
+
+@Injectable()
+export class StatsReconcileCron implements OnModuleInit {
+  private readonly logger = new Logger(StatsReconcileCron.name);
+  private isRunning = false;
+
+  constructor(
+    private readonly config: ConfigService,
+    private readonly scheduler: SchedulerRegistry,
+    private readonly stats: StatsService
+  ) {}
+
+  onModuleInit(): void {
+    if (!this.config.get<boolean>('CRON_ENABLED', true)) {
+      this.logger.log('CRON_ENABLED=false → stats-reconcile not scheduled');
+      return;
+    }
+    const expr = this.config.get<string>('RECONCILE_CRON', '0 3 * * *');
+    const job = new CronJob(expr, () => {
+      void this.run();
+    });
+    this.scheduler.addCronJob('stats-reconcile', job);
+    job.start();
+    this.logger.log(`stats-reconcile scheduled: ${expr}`);
+  }
+
+  async run(): Promise<void> {
+    if (this.isRunning) {
+      this.logger.warn('stats-reconcile already running; skipping tick');
+      return;
+    }
+    this.isRunning = true;
+    const start = Date.now();
+    try {
+      const result = await this.stats.recomputeAll();
+      this.logger.log(
+        `stats-reconcile done users=${result.users} durationMs=${Date.now() - start}`
+      );
+    } catch (err) {
+      this.logger.error(`stats-reconcile failed: ${(err as Error).message}`);
+    } finally {
+      this.isRunning = false;
+    }
+  }
+}
+```
+
+- [ ] **Step 2: Create `dispute-sla.cron.ts`**
+
+```ts
+import { Injectable, Logger, type OnModuleInit } from '@nestjs/common';
+// biome-ignore lint/style/useImportType: required for NestJS dependency injection
+import { ConfigService } from '@nestjs/config';
+// biome-ignore lint/style/useImportType: required for NestJS dependency injection
+import { SchedulerRegistry } from '@nestjs/schedule';
+// biome-ignore lint/style/useImportType: required for NestJS dependency injection
+import { DisputesService } from '@domains/platform/disputes/disputes.service';
+import { CronJob } from 'cron';
+
+@Injectable()
+export class DisputeSlaCron implements OnModuleInit {
+  private readonly logger = new Logger(DisputeSlaCron.name);
+  private isRunning = false;
+
+  constructor(
+    private readonly config: ConfigService,
+    private readonly scheduler: SchedulerRegistry,
+    private readonly disputes: DisputesService
+  ) {}
+
+  onModuleInit(): void {
+    if (!this.config.get<boolean>('CRON_ENABLED', true)) {
+      this.logger.log('CRON_ENABLED=false → dispute-sla not scheduled');
+      return;
+    }
+    const expr = this.config.get<string>('DISPUTE_SLA_CRON', '0 * * * *');
+    const job = new CronJob(expr, () => {
+      void this.run();
+    });
+    this.scheduler.addCronJob('dispute-sla', job);
+    job.start();
+    this.logger.log(`dispute-sla scheduled: ${expr}`);
+  }
+
+  async run(): Promise<void> {
+    if (this.isRunning) {
+      this.logger.warn('dispute-sla already running; skipping tick');
+      return;
+    }
+    this.isRunning = true;
+    try {
+      const thresholdHours = this.config.get<number>('DISPUTE_SLA_HOURS', 48);
+      const overdue = await this.disputes.findOverdueDisputes(
+        Date.now(),
+        thresholdHours
+      );
+      for (const d of overdue) {
+        this.logger.warn(
+          `dispute_sla_breach escrowId=${d.escrowId} engagementId=${d.engagementId} ` +
+            `buyerId=${d.buyerId} sellerId=${d.sellerId} hoursOpen=${d.hoursOpen}`
+        );
+      }
+      this.logger.log(
+        `dispute-sla done thresholdHours=${thresholdHours} overdueCount=${overdue.length}`
+      );
+    } catch (err) {
+      this.logger.error(`dispute-sla failed: ${(err as Error).message}`);
+    } finally {
+      this.isRunning = false;
+    }
+  }
+}
+```
+
+- [ ] **Step 3: Write `dispute-sla.cron.spec.ts` (alert emission)**
+
+```ts
+import { Logger } from '@nestjs/common';
+import type { ConfigService } from '@nestjs/config';
+import type { SchedulerRegistry } from '@nestjs/schedule';
+import type { DisputesService, OverdueDispute } from '@domains/platform/disputes/disputes.service';
+import { DisputeSlaCron } from '@domains/platform/jobs/dispute-sla.cron';
+
+describe('DisputeSlaCron.run', () => {
+  it('logs a breach per overdue dispute and a summary count', async () => {
+    const overdue: OverdueDispute[] = [
+      { escrowId: 'e1', engagementId: 'eng1', buyerId: 'b1', sellerId: 's1', disputeRaisedAt: 'x', hoursOpen: 50 },
+      { escrowId: 'e2', engagementId: 'eng2', buyerId: 'b2', sellerId: 's2', disputeRaisedAt: 'y', hoursOpen: 72 },
+    ];
+    const config = { get: <T>(_k: string, d?: T) => d } as unknown as ConfigService;
+    const scheduler = {} as unknown as SchedulerRegistry;
+    const disputes = { findOverdueDisputes: jest.fn().mockResolvedValue(overdue) } as unknown as DisputesService;
+
+    const warn = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+    const log = jest.spyOn(Logger.prototype, 'log').mockImplementation(() => undefined);
+
+    const cron = new DisputeSlaCron(config, scheduler, disputes);
+    await cron.run();
+
+    expect(disputes.findOverdueDisputes).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledTimes(2);
+    expect(warn.mock.calls[0][0]).toContain('dispute_sla_breach');
+    expect(log.mock.calls.some((c) => String(c[0]).includes('overdueCount=2'))).toBe(true);
+
+    warn.mockRestore();
+    log.mockRestore();
+  });
+});
+```
+
+- [ ] **Step 4: Run to verify the cron test passes**
+
+Run: `cd apps/backend && npm test -- dispute-sla`
+Expected: PASS (1 test). If `findOverdueDisputes` typing complains, ensure the mock cast matches.
+
+- [ ] **Step 5: Create `jobs.module.ts`**
+
+```ts
+import { Module } from '@nestjs/common';
+import { DisputesModule } from '@domains/platform/disputes/disputes.module';
+import { DisputeSlaCron } from '@domains/platform/jobs/dispute-sla.cron';
+import { StatsReconcileCron } from '@domains/platform/jobs/stats-reconcile.cron';
+import { StatsModule } from '@domains/platform/stats/stats.module';
+
+@Module({
+  imports: [StatsModule, DisputesModule],
+  providers: [StatsReconcileCron, DisputeSlaCron],
+})
+export class JobsModule {}
+```
+
+- [ ] **Step 6: Add `JobsModule` to `apps/backend/src/domains/platform/platform.module.ts`**
+
+Add `import { JobsModule } from '@domains/platform/jobs/jobs.module';` and add `JobsModule` to the `imports` array (alongside `StatsModule`).
+
+- [ ] **Step 7: Build + boot smoke (both jobs register) + DI check**
+
+```bash
+rm -rf apps/backend/dist apps/backend/*.tsbuildinfo
+cd apps/backend && npm run build && cd ../..
+grep -n "design:paramtypes" apps/backend/dist/domains/platform/jobs/dispute-sla.cron.js
+# → must reference ConfigService, SchedulerRegistry, DisputesService (not [void 0])
+( cd apps/backend && node dist/main.js & sleep 2 ; kill %1 ) 2>&1 | grep -iE "scheduled:|not scheduled"
+# → expect: "stats-reconcile scheduled: 0 3 * * *" and "dispute-sla scheduled: 0 * * * *"
+rm -rf apps/backend/dist apps/backend/*.tsbuildinfo
+```
+Expected: both "scheduled" log lines appear; DI metadata references the real classes. (Booting needs `apps/backend/.env` with the existing real Supabase + INTERNAL_API_KEY values; the crons won't fire on the default 3am/hourly schedules during this short boot, which is fine — we only assert registration.)
+
+- [ ] **Step 8: Verify CRON_ENABLED=false disables registration**
+
+```bash
+( cd apps/backend && CRON_ENABLED=false node dist/main.js & sleep 2 ; kill %1 ) 2>&1 | grep -i "not scheduled"
+```
+First `npm run build`. Expected: two "not scheduled" lines (jobs skip registration). Clean up dist afterward.
+
+- [ ] **Step 9: Biome + type-check + full backend test + commit**
+
+```bash
+cd apps/backend && npm run biome:fix && npm run biome:check && npm test && cd ../..
+npm run type-check
+git add apps/backend/src/domains/platform/jobs apps/backend/src/domains/platform/platform.module.ts
+git commit -m "feat(backend): add stats-reconcile + dispute-sla cron jobs (#137)"
+```
+
+---
+
+## Task 4: Final verification + PR
+
+**Files:** none (verification + PR)
+
+- [ ] **Step 1: Full verification**
+
+```bash
+cd apps/backend && npm test && npm run biome:check && cd ../..
+rm -rf apps/backend/dist apps/backend/*.tsbuildinfo
+npm run type-check
+npm run build
+```
+Expected: Jest green (reputation, trade-summary, stats, disputes, dispute-sla cron); backend biome clean; type-check + build pass.
+
+- [ ] **Step 2: Runtime smoke (optional, with a short schedule)**
+
+To see a job actually fire, temporarily run with a seconds-based schedule:
+```bash
+cd apps/backend && rm -rf dist *.tsbuildinfo && npm run build && \
+  RECONCILE_CRON='*/5 * * * * *' node dist/main.js & sleep 8 ; kill %1
+```
+Expected: within ~5s a `stats-reconcile done users=… durationMs=…` log line appears (requires the real Supabase env). Clean up dist.
+
+- [ ] **Step 3: Push + open PR**
+
+```bash
+git push -u origin feat/137-cron-jobs
+gh pr create --repo PACTO-LAT/pacto-p2p --base develop --head feat/137-cron-jobs \
+  --title "feat(backend): scheduled cleanup & SLA jobs / cron (phase 3 — #137)" \
+  --body "<summary; note access-code cleanup deferred (orphaned feature); SLA via existing data + pino log; depends on #136>"
+```
+(No `Co-Authored-By`, no "Generated with Claude" footer.) Note in the PR that this branch is stacked on #136 — if #136 isn't merged yet, the diff includes phase-2 commits until it is.
+
+---
+
+## Self-review checklist (completed during planning)
+
+- **Spec coverage:** cron infra + ScheduleModule + env (T1); dispute SLA query + pure selection + tests (T2); both cron jobs + overlap guard + CRON_ENABLED + alert logging + reconcile (T3); verification + PR (T4). Access-code cleanup intentionally absent (deferred per spec — orphaned feature). Nightly reconcile = `StatsService.recomputeAll()` (T3). All in-scope spec items covered.
+- **Type consistency:** `DisputeRow`/`OverdueDispute` defined in `disputes.service.ts` (T2) and consumed by the cron + its spec (T3) unchanged. `StatsService.recomputeAll()` returns `{ users: number }` (phase 2) — used in the reconcile log.
+- **No placeholders:** every code step is complete; the only `<...>` is the PR body text.
+- **Known external-API notes:** `@nestjs/schedule` version is a caret range (align to the Nest-11-compatible major at install). `CronJob` is imported from `cron` (bundled by `@nestjs/schedule`). Schedules are registered via `SchedulerRegistry` in `onModuleInit` (not `@Cron`) precisely because the expressions come from env at runtime. The supabase-js embedded-resource select (`trade_chats!inner(...escrows!inner(...))`) filters escrow status in JS (in `selectOverdue`) to avoid finicky nested-resource filters.
+- **Out of scope (per spec):** access-code cleanup, robust dispute persistence (phase 4), real alert delivery (phase 5), multi-instance cron locking, the `listings`/`waitlist_submissions` RLS finding.

--- a/docs/superpowers/specs/2026-06-26-backend-phase3-cron-design.md
+++ b/docs/superpowers/specs/2026-06-26-backend-phase3-cron-design.md
@@ -1,0 +1,132 @@
+# Backend Phase 3 — Scheduled Jobs / Cron (Issue #137)
+
+**Status:** Design approved (pending spec review)
+**Date:** 2026-06-26
+**Issue:** [#137 — feat(backend): scheduled cleanup & SLA jobs / cron (phase 3)](https://github.com/PACTO-LAT/pacto-p2p/issues/137)
+**Depends on:** #135 (scaffold, merged), #136 (stats pipeline — PR open; this branch is stacked on `feat/136-stats-reputation`).
+
+## Context
+
+This phase adds **cron infrastructure** (`@nestjs/schedule`) to `apps/backend` and the scheduled jobs
+that back phase 2's stats and surface stuck disputes. Cron jobs are timer-driven maintenance — no
+user action, no user-visible features.
+
+### What the jobs are for
+- **Nightly stats reconcile** — phase 2's real-time recompute is best-effort/fire-and-forget; if a
+  trigger is missed (network failure, closed tab, the sync path that can't pass both party ids) or
+  data is edited directly, the persisted stats drift. A full nightly `recomputeAll()` makes them
+  self-heal (eventual correctness).
+- **Dispute SLA alert** — a disputed trade freezes funds on-chain until an admin resolves it
+  manually; nothing today flags a dispute that has been open too long. This job scans for overdue
+  disputes and logs an alert so the team can act.
+
+### Key findings from exploration (shape the design)
+- **`access_codes` does not exist** (no migration, not in the remote DB) and **nothing calls**
+  `apps/web/app/api/access/verify/route.ts`. The access-code feature is an orphaned stub. → The
+  issue's "expired access-code cleanup" job is **dropped from this phase** (nothing to clean); the
+  orphan is flagged separately.
+- **Disputes are not persisted with a status/timestamp.** Raising a dispute writes
+  `escrows.transaction_hashes.dispute` (a tx hash) and inserts a `trade_messages` system row with
+  `metadata->>'event' = 'dispute_raised'` (its `created_at` is the only reliable "disputed at"
+  timestamp). `escrows.status` stays `'active'` (the enum is `active|cancelled|completed|resolved`;
+  there is **no** `'disputed'`). Resolving sets `escrows.status = 'resolved'`. So an **open dispute
+  = an escrow still `status='active'` that has a `dispute_raised` system message**.
+- `StatsService.recomputeAll()` already exists (phase 2) and is idempotent — the reconcile job calls
+  it in-process.
+- Jest is already set up (phase 2). `@nestjs/schedule` is not yet installed.
+
+## Decisions (approved)
+
+1. **Two jobs only:** nightly stats reconcile + dispute SLA. **Access-code cleanup deferred** (feature
+   doesn't exist); flag the orphaned verify route separately.
+2. **Dispute SLA data source:** query the existing data (no migration) — `trade_messages`
+   (`dispute_raised`) joined to its `trade_chats` + `escrows`, filtering escrows still `status='active'`
+   and message `created_at` older than the threshold.
+3. **Alert delivery:** structured pino log only ("minimal at first"); real notifications are phase 5
+   (#139). No new table.
+
+## Architecture (extends `domains/platform`)
+
+```
+apps/backend/src/domains/platform/
+├── disputes/
+│   ├── disputes.module.ts
+│   ├── disputes.service.ts        # findOverdueDisputes(now, thresholdHours) — query + pure filter
+│   └── disputes.service.spec.ts   # overdue-selection unit tests (deterministic)
+├── jobs/
+│   ├── jobs.module.ts             # imports StatsModule + DisputesModule; declares the two crons
+│   ├── stats-reconcile.cron.ts    # @Cron → StatsService.recomputeAll()
+│   ├── dispute-sla.cron.ts        # @Cron → DisputesService.findOverdueDisputes() → log
+│   └── cron.config.ts             # reads cron schedules/threshold/enabled from ConfigService
+platform.module.ts                 # + JobsModule (and DisputesModule via JobsModule)
+app.module.ts                      # + ScheduleModule.forRoot()
+```
+
+Both `.cron.ts` providers share a small **overlap guard** (a private `isRunning` boolean) so a slow
+run can't overlap the next tick, and wrap the work in try/catch that logs and never throws (a failing
+job must not crash the process). They use the Nest `Logger`/pino for structured start/finish/error
+logs with durations and counts.
+
+## Components
+
+### `cron.config.ts` / env (Joi, all optional with defaults)
+| Env | Default | Meaning |
+|---|---|---|
+| `CRON_ENABLED` | `true` | master switch (set `false` to disable all crons, e.g. on non-primary instances) |
+| `RECONCILE_CRON` | `0 3 * * *` | nightly stats reconcile schedule |
+| `DISPUTE_SLA_CRON` | `0 * * * *` | dispute SLA scan schedule (hourly) |
+| `DISPUTE_SLA_HOURS` | `48` | a dispute open longer than this is "overdue" |
+
+`@Cron` expressions are read via `ConfigService`. When `CRON_ENABLED=false`, each job's handler
+early-returns (the decorator still registers, but does nothing) — simplest reliable toggle.
+
+### `stats-reconcile.cron.ts`
+`@Cron(RECONCILE_CRON)` handler: overlap-guarded; logs `reconcile.start`; calls
+`StatsService.recomputeAll()`; logs `reconcile.done { users, durationMs }`. Errors logged, swallowed.
+
+### `disputes.service.ts`
+`findOverdueDisputes(now: number, thresholdHours: number): Promise<OverdueDispute[]>`:
+1. Compute `cutoffIso = new Date(now - thresholdHours*3600_000).toISOString()`.
+2. Query (service-role): from `trade_messages` where `message_type='system'` and
+   `metadata->>'event'='dispute_raised'` and `created_at <= cutoffIso`, embedding
+   `trade_chats!inner(escrow_id, buyer_id, seller_id, escrows!inner(status, engagement_id))`.
+3. In JS, keep rows whose embedded `escrows.status === 'active'` (i.e. not resolved/cancelled/
+   completed) → map to `{ escrowId, engagementId, buyerId, sellerId, disputeRaisedAt, hoursOpen }`.
+   (Status is filtered in JS to avoid finicky supabase-js nested-resource filters; volume is low.)
+
+A small pure helper `selectOverdue(rows, now, thresholdHours)` does the status + age mapping and is
+unit-tested directly; the service just supplies the DB rows.
+
+### `dispute-sla.cron.ts`
+`@Cron(DISPUTE_SLA_CRON)` handler: overlap-guarded; calls `findOverdueDisputes(Date.now(),
+DISPUTE_SLA_HOURS)`; for each overdue dispute logs a structured `warn`
+`{ event:'dispute_sla_breach', escrowId, engagementId, buyerId, sellerId, hoursOpen }`; logs a summary
+`{ overdueCount }`. No DB writes, no external delivery (phase 5).
+
+## Testing (Jest)
+- `disputes.service.spec.ts`: unit-test `selectOverdue` (and/or the service with a mocked Supabase
+  client like phase 2): given dispute rows raised at various times with escrows in various statuses,
+  it returns ONLY `status='active'` disputes older than the threshold, with correct `hoursOpen`;
+  `now` is injected for determinism; resolved/cancelled/completed disputes and recent ones are
+  excluded.
+- The reconcile cron is thin (delegates to the already-tested `StatsService.recomputeAll`); verify by
+  build + a runtime smoke (manually invoke the handler or wait for a tick) rather than re-testing
+  recompute.
+
+## Verification (end-to-end)
+1. `cd apps/backend && npm test` → all suites green (incl. new disputes tests).
+2. Root `npm run type-check`, `npm run build`; backend `npm run biome:check` clean.
+3. Boot backend; with `CRON_ENABLED=true` and short test schedules (or by invoking handlers directly),
+   confirm: reconcile logs `{users, durationMs}` and updates persist; dispute-SLA logs
+   `dispute_sla_breach` for seeded overdue disputes and nothing for recent/resolved ones. With
+   `CRON_ENABLED=false`, neither job does work.
+
+## Out of scope
+- **Access-code cleanup** (orphaned, non-existent feature) — deferred; orphan flagged separately.
+- **Robust dispute persistence** (`escrows.dispute_status`/`disputed_at`) — better suited to phase 4
+  (escrow indexing, #138); this phase reads existing data.
+- **Real alert delivery** (email/in-app) — phase 5 (#139); this phase logs only.
+- **Multi-instance cron coordination** (distributed lock) — single-instance assumption; `CRON_ENABLED`
+  lets you disable crons on extra instances. Revisit if the backend scales horizontally.
+- **`listings`/`waitlist_submissions` RLS disabled** — a separate security finding surfaced during
+  exploration; tracked outside this issue.

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "@nestjs/config": "^4.0.0",
         "@nestjs/core": "^11.0.0",
         "@nestjs/platform-express": "^11.0.0",
+        "@nestjs/schedule": "^5.0.0",
         "@nestjs/swagger": "^11.0.0",
         "@nestjs/terminus": "^11.0.0",
         "@nestjs/throttler": "^6.0.0",
@@ -3891,6 +3892,19 @@
       "peerDependencies": {
         "@nestjs/common": "^11.0.0",
         "@nestjs/core": "^11.0.0"
+      }
+    },
+    "node_modules/@nestjs/schedule": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/schedule/-/schedule-5.0.1.tgz",
+      "integrity": "sha512-kFoel84I4RyS2LNPH6yHYTKxB16tb3auAEciFuc788C3ph6nABkUfzX5IE+unjVaRX+3GuruJwurNepMlHXpQg==",
+      "license": "MIT",
+      "dependencies": {
+        "cron": "3.5.0"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^10.0.0 || ^11.0.0"
       }
     },
     "node_modules/@nestjs/schematics": {
@@ -8728,6 +8742,12 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "license": "MIT"
     },
+    "node_modules/@types/luxon": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.4.2.tgz",
+      "integrity": "sha512-TifLZlFudklWlMBfhubvgqTXRzLDI5pCbGa4P8a3wPyUQSW+1xQ5eDsreP9DWHX3tjq1ke96uYG/nwundroWcA==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "20.19.7",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.7.tgz",
@@ -12060,6 +12080,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cron": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-3.5.0.tgz",
+      "integrity": "sha512-0eYZqCnapmxYcV06uktql93wNWdlTmmBFP2iYz+JPVcQqlyFYcn1lFuIk4R54pkOmE7mcldTAPZv6X5XA4Q46A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/luxon": "~3.4.0",
+        "luxon": "~3.5.0"
       }
     },
     "node_modules/cross-fetch": {
@@ -16301,6 +16331,15 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.5.0.tgz",
+      "integrity": "sha512-rh+Zjr6DNfUYR3bPwJEnuwDdqMbxZW7LOQfUN4B54+Cl+0o5zaU9RJ6bcidfDtC1cWCZXQ+nvX8bf6bAji37QQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/magic-string": {


### PR DESCRIPTION
## Summary

Phase 3 of the backend rollout (#137). Adds **cron infrastructure** (`@nestjs/schedule`) to `apps/backend` and two scheduled jobs. Cron jobs are timer-driven maintenance — no user-facing features. Depends on #136 (already merged to `develop`).

- **Cron infra:** `ScheduleModule.forRoot()` + env-driven schedules. Each job registers via `SchedulerRegistry` in `onModuleInit` (so the cron expression is read from config at runtime, which the `@Cron` decorator can't do), is **overlap-guarded** (`isRunning`), and **never throws** (a failed job can't crash the process). `CRON_ENABLED=false` disables registration.
- **Nightly stats reconcile** (`RECONCILE_CRON`, default `0 3 * * *`): calls the idempotent `StatsService.recomputeAll()` (phase 2) so any drift from the best-effort real-time triggers self-heals. Logs `users` + `durationMs`.
- **Dispute SLA scan** (`DISPUTE_SLA_CRON`, default hourly): finds disputes open longer than `DISPUTE_SLA_HOURS` (default 48) and logs a structured `dispute_sla_breach` per overdue dispute + a summary count.

closes #137 

## Aggregation / data sources (documented choices)

- **Dispute SLA uses existing data, no migration:** disputes aren't persisted with a status, so the job joins `trade_messages` (`event='dispute_raised'`) → `trade_chats` → `escrows`, keeping escrows still `status='active'` (not resolved/cancelled/completed) whose dispute message is older than the threshold. The overdue-selection logic is a pure, unit-tested function (`selectOverdue`).
- **Alert delivery is log-only** ("minimal at first"); real email/in-app notifications are phase 5 (#139).

## Acceptance criteria

- [x] Nightly stats reconcile runs and matches incremental values — wired to the idempotent `recomputeAll()`, overlap-guarded.
- [x] Dispute SLA job emits an alert/flag for overdue disputes — structured `dispute_sla_breach` log per overdue + count (delivery minimal, per the issue).
- [ ] **Expired access-code cleanup — intentionally deferred.** The `access_codes` feature is an orphaned stub: the table does **not exist** (no migration, not in the DB) and **nothing calls** `apps/web/app/api/access/verify/route.ts`. Building cleanup for a non-existent feature made no sense; this is documented in the spec and should be revisited if/when the access-code feature is actually built.

## Test plan / verification

- `cd apps/backend && npm test` → all suites green (incl. `selectOverdue` cases + the dispute-SLA cron alert-emission test).
- `npm run type-check` + `npm run build` (root) pass; backend `biome:check` clean.
- Boot smoke: with `CRON_ENABLED=true` both jobs log `… scheduled: <expr>`; with `CRON_ENABLED=false` both log `… not scheduled`. (To watch one fire, run with a seconds schedule e.g. `RECONCILE_CRON='*/5 * * * * *'`.)

## Notes for reviewers

- **Depends on #136** (the reconcile calls phase-2's `StatsService.recomputeAll`).
- The dispute SLA relies on the `dispute_raised` system chat message as the "disputed at" timestamp; a robust persisted `dispute_status`/`disputed_at` is better suited to **phase 4** (#138, escrow indexing).
- Single-instance assumption; `CRON_ENABLED` lets you disable crons on extra instances (no distributed lock yet).
- Separate finding surfaced during exploration (not in this PR): `listings` and `waitlist_submissions` have RLS disabled — worth a dedicated security issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added scheduled background jobs for nightly stats reconciliation and dispute SLA checks.
  * Introduced configurable cron settings and an on/off toggle for scheduled tasks.
  * Added dispute overdue detection and logging for items past the SLA threshold.

* **Bug Fixes**
  * Prevents overlapping cron runs to avoid duplicate processing.
  * Improves handling of missing or invalid dispute data when identifying overdue items.

* **Tests**
  * Added automated coverage for overdue-dispute selection and cron job behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->