### PR TITLE
feat: notification service (#139)

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -41,3 +41,7 @@ TLW_NETWORK=testnet
 PLATFORM_ROLE_ADDRESS=
 # Escrow indexer schedule
 ESCROW_INDEX_CRON=*/2 * * * *
+
+# Email notifications via Resend (leave RESEND_API_KEY empty to disable email; in-app notifications still work)
+RESEND_API_KEY=
+EMAIL_FROM=Pacto <no-reply@pacto.app>

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -34,6 +34,7 @@
     "nestjs-pino": "^4.1.0",
     "pino-http": "^10.0.0",
     "reflect-metadata": "^0.2.2",
+    "resend": "^4.8.0",
     "rxjs": "^7.8.1"
   },
   "devDependencies": {

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -2,6 +2,7 @@ import { InternalApiKeyGuard } from '@common/guards/internal-api-key.guard';
 import { envValidationSchema } from '@config/env.validation';
 import { CoreModule } from '@core/core.module';
 import { EscrowModule } from '@domains/escrow/escrow.module';
+import { NotificationsModule } from '@domains/notifications/notifications.module';
 import { PlatformModule } from '@domains/platform/platform.module';
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
@@ -36,6 +37,7 @@ import { LoggerModule } from 'nestjs-pino';
     CoreModule,
     PlatformModule,
     EscrowModule,
+    NotificationsModule,
   ],
   providers: [
     { provide: APP_GUARD, useClass: ThrottlerGuard },

--- a/apps/backend/src/config/env.validation.ts
+++ b/apps/backend/src/config/env.validation.ts
@@ -26,4 +26,6 @@ export const envValidationSchema = Joi.object({
   TLW_NETWORK: Joi.string().valid('testnet', 'mainnet').default('testnet'),
   PLATFORM_ROLE_ADDRESS: Joi.string().allow('').default(''),
   ESCROW_INDEX_CRON: Joi.string().default('*/2 * * * *'),
+  RESEND_API_KEY: Joi.string().allow('').default(''),
+  EMAIL_FROM: Joi.string().default('Pacto <no-reply@pacto.app>'),
 });

--- a/apps/backend/src/core/core.module.ts
+++ b/apps/backend/src/core/core.module.ts
@@ -1,9 +1,10 @@
+import { EmailModule } from '@core/email/email.module';
 import { HealthModule } from '@core/health/health.module';
 import { SupabaseModule } from '@core/supabase/supabase.module';
 import { TrustlessModule } from '@core/trustless/trustless.module';
 import { Module } from '@nestjs/common';
 
 @Module({
-  imports: [SupabaseModule, HealthModule, TrustlessModule],
+  imports: [SupabaseModule, HealthModule, TrustlessModule, EmailModule],
 })
 export class CoreModule {}

--- a/apps/backend/src/core/email/email.module.ts
+++ b/apps/backend/src/core/email/email.module.ts
@@ -1,0 +1,9 @@
+import { EmailService } from '@core/email/email.service';
+import { Global, Module } from '@nestjs/common';
+
+@Global()
+@Module({
+  providers: [EmailService],
+  exports: [EmailService],
+})
+export class EmailModule {}

--- a/apps/backend/src/core/email/email.service.spec.ts
+++ b/apps/backend/src/core/email/email.service.spec.ts
@@ -1,0 +1,37 @@
+import { EmailService } from '@core/email/email.service';
+import type { ConfigService } from '@nestjs/config';
+
+function cfg(values: Record<string, string>): ConfigService {
+  return {
+    get: <T>(k: string, d?: T) => (values[k] as unknown as T) ?? d,
+  } as unknown as ConfigService;
+}
+
+describe('EmailService', () => {
+  const ORIGINAL_FETCH = global.fetch;
+  afterEach(() => {
+    global.fetch = ORIGINAL_FETCH;
+    jest.restoreAllMocks();
+  });
+
+  it('isEnabled is false when RESEND_API_KEY is empty', () => {
+    expect(new EmailService(cfg({})).isEnabled()).toBe(false);
+    expect(new EmailService(cfg({ RESEND_API_KEY: 're_x' })).isEnabled()).toBe(
+      true
+    );
+  });
+
+  it('send returns skipped and makes NO network call when disabled', async () => {
+    const fetchMock = jest.fn();
+    global.fetch = fetchMock as unknown as typeof fetch;
+    const svc = new EmailService(cfg({}));
+    const res = await svc.send({
+      to: 'a@b.com',
+      subject: 's',
+      html: '<p>x</p>',
+      text: 'x',
+    });
+    expect(res.status).toBe('skipped');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/core/email/email.service.ts
+++ b/apps/backend/src/core/email/email.service.ts
@@ -15,16 +15,19 @@ export type EmailSendStatus = 'sent' | 'failed' | 'skipped';
 @Injectable()
 export class EmailService {
   private readonly logger = new Logger(EmailService.name);
+  private readonly resend: Resend | null;
 
-  constructor(private readonly config: ConfigService) {}
+  constructor(private readonly config: ConfigService) {
+    const apiKey = this.config.get<string>('RESEND_API_KEY', '');
+    this.resend = apiKey ? new Resend(apiKey) : null;
+  }
 
   isEnabled(): boolean {
-    return !!this.config.get<string>('RESEND_API_KEY');
+    return this.resend !== null;
   }
 
   async send(input: SendEmailInput): Promise<{ status: EmailSendStatus }> {
-    const apiKey = this.config.get<string>('RESEND_API_KEY', '');
-    if (!apiKey) {
+    if (this.resend === null) {
       return { status: 'skipped' };
     }
     const from = this.config.get<string>(
@@ -32,8 +35,7 @@ export class EmailService {
       'Pacto <no-reply@pacto.app>'
     );
     try {
-      const resend = new Resend(apiKey);
-      const { error } = await resend.emails.send({
+      const { error } = await this.resend.emails.send({
         from,
         to: input.to,
         subject: input.subject,

--- a/apps/backend/src/core/email/email.service.ts
+++ b/apps/backend/src/core/email/email.service.ts
@@ -1,0 +1,53 @@
+import { Injectable, Logger } from '@nestjs/common';
+// biome-ignore lint/style/useImportType: required for NestJS dependency injection
+import { ConfigService } from '@nestjs/config';
+import { Resend } from 'resend';
+
+export interface SendEmailInput {
+  to: string;
+  subject: string;
+  html: string;
+  text: string;
+}
+
+export type EmailSendStatus = 'sent' | 'failed' | 'skipped';
+
+@Injectable()
+export class EmailService {
+  private readonly logger = new Logger(EmailService.name);
+
+  constructor(private readonly config: ConfigService) {}
+
+  isEnabled(): boolean {
+    return !!this.config.get<string>('RESEND_API_KEY');
+  }
+
+  async send(input: SendEmailInput): Promise<{ status: EmailSendStatus }> {
+    const apiKey = this.config.get<string>('RESEND_API_KEY', '');
+    if (!apiKey) {
+      return { status: 'skipped' };
+    }
+    const from = this.config.get<string>(
+      'EMAIL_FROM',
+      'Pacto <no-reply@pacto.app>'
+    );
+    try {
+      const resend = new Resend(apiKey);
+      const { error } = await resend.emails.send({
+        from,
+        to: input.to,
+        subject: input.subject,
+        html: input.html,
+        text: input.text,
+      });
+      if (error) {
+        this.logger.error(`email send failed: ${error.message}`);
+        return { status: 'failed' };
+      }
+      return { status: 'sent' };
+    } catch (err) {
+      this.logger.error(`email send threw: ${(err as Error).message}`);
+      return { status: 'failed' };
+    }
+  }
+}

--- a/apps/backend/src/core/email/templates/escrow-released.template.spec.ts
+++ b/apps/backend/src/core/email/templates/escrow-released.template.spec.ts
@@ -1,0 +1,31 @@
+import { renderEscrowReleasedEmail } from '@core/email/templates/escrow-released.template';
+
+describe('renderEscrowReleasedEmail', () => {
+  it('produces subject/text/html and greets by name when provided', () => {
+    const out = renderEscrowReleasedEmail({
+      recipientName: 'Alice',
+      role: 'buyer',
+      engagementId: 'eng1',
+      amount: 250,
+    });
+    expect(out.subject).toMatch(/liberad/i);
+    expect(out.text).toContain('Alice');
+    expect(out.text).toContain('eng1');
+    expect(out.html).toContain('eng1');
+  });
+
+  it('uses seller copy and a generic greeting without a name', () => {
+    const buyer = renderEscrowReleasedEmail({
+      role: 'buyer',
+      engagementId: 'e',
+      amount: 1,
+    });
+    const seller = renderEscrowReleasedEmail({
+      role: 'seller',
+      engagementId: 'e',
+      amount: 1,
+    });
+    expect(seller.text).not.toEqual(buyer.text);
+    expect(seller.text).toContain('Hola,');
+  });
+});

--- a/apps/backend/src/core/email/templates/escrow-released.template.spec.ts
+++ b/apps/backend/src/core/email/templates/escrow-released.template.spec.ts
@@ -11,6 +11,7 @@ describe('renderEscrowReleasedEmail', () => {
     expect(out.subject).toMatch(/liberad/i);
     expect(out.text).toContain('Alice');
     expect(out.text).toContain('eng1');
+    expect(out.text).toContain('250');
     expect(out.html).toContain('eng1');
   });
 

--- a/apps/backend/src/core/email/templates/escrow-released.template.ts
+++ b/apps/backend/src/core/email/templates/escrow-released.template.ts
@@ -1,0 +1,31 @@
+export interface EscrowReleasedEmailData {
+  recipientName?: string;
+  role: 'buyer' | 'seller';
+  engagementId: string;
+  amount: number;
+}
+
+export interface RenderedEmail {
+  subject: string;
+  html: string;
+  text: string;
+}
+
+export function renderEscrowReleasedEmail(
+  data: EscrowReleasedEmailData
+): RenderedEmail {
+  const greeting = data.recipientName ? `Hola ${data.recipientName},` : 'Hola,';
+  const line =
+    data.role === 'buyer'
+      ? `Los fondos de tu escrow ${data.engagementId} fueron liberados al vendedor.`
+      : `Se liberaron los fondos del escrow ${data.engagementId}. La operación se completó.`;
+  const subject = 'Pacto — Fondos liberados';
+  const text = `${greeting}\n\n${line}\n\nMonto: ${data.amount}\n\n— Pacto`;
+  const html = `<div style="font-family:sans-serif;color:#111">
+  <p>${greeting}</p>
+  <p>${line}</p>
+  <p><strong>Monto:</strong> ${data.amount}</p>
+  <p style="color:#059669">— Pacto</p>
+</div>`;
+  return { subject, html, text };
+}

--- a/apps/backend/src/domains/escrow/escrow-indexer.service.spec.ts
+++ b/apps/backend/src/domains/escrow/escrow-indexer.service.spec.ts
@@ -1,21 +1,31 @@
-// biome-ignore lint/suspicious/noExplicitAny: test mock
 import type { SupabaseService } from '@core/supabase/supabase.service';
 import type { TrustlessIndexerService } from '@core/trustless/trustless-indexer.service';
 import { EscrowIndexerService } from '@domains/escrow/escrow-indexer.service';
+import type { NotificationsService } from '@domains/notifications/notifications.service';
 
-function makeSupabase() {
+// Mock: notifications row read via select().eq().maybeSingle(); escrow update via update().eq().
+function makeSupabase(existing: any | null) {
   const updates: Array<{ match: string; payload: any }> = [];
   const client = {
-    from() {
+    from(_table: string) {
       const b: any = {
-        _payload: null,
+        _payload: null as any,
+        select() {
+          return b;
+        },
         update(p: any) {
           b._payload = p;
           return b;
         },
+        maybeSingle() {
+          return Promise.resolve({ data: existing, error: null });
+        },
         eq(_col: string, val: string) {
-          if (b._payload) updates.push({ match: val, payload: b._payload });
-          return Promise.resolve({ data: null, error: null });
+          if (b._payload) {
+            updates.push({ match: val, payload: b._payload });
+            return Promise.resolve({ data: null, error: null });
+          }
+          return b;
         },
       };
       return b;
@@ -24,35 +34,122 @@ function makeSupabase() {
   return { service: { client } as unknown as SupabaseService, updates };
 }
 
-describe('EscrowIndexerService.indexAll', () => {
-  const indexer = (escrows: any[]) =>
-    ({
-      isConfigured: () => true,
-      getPlatformEscrows: jest.fn().mockResolvedValue(escrows),
-    }) as unknown as TrustlessIndexerService;
+const indexerWith = (escrows: any[]) =>
+  ({
+    isConfigured: () => true,
+    getPlatformEscrows: jest.fn().mockResolvedValue(escrows),
+  }) as unknown as TrustlessIndexerService;
 
-  it('updates each escrow row with the mapped patch (matched by engagement_id)', async () => {
-    const { service, updates } = makeSupabase();
-    const svc = new EscrowIndexerService(
+const notifySpy = () => {
+  const onEscrowReleased = jest.fn().mockResolvedValue(undefined);
+  return {
+    svc: { onEscrowReleased } as unknown as NotificationsService,
+    onEscrowReleased,
+  };
+};
+
+describe('EscrowIndexerService.indexAll', () => {
+  it('updates the matched escrow row with the mapped patch', async () => {
+    const { service, updates } = makeSupabase({
+      id: 'esc-1',
+      on_chain_status: 'active',
+      buyer_id: 'b',
+      seller_id: 's',
+    });
+    const { svc } = notifySpy();
+    const res = await new EscrowIndexerService(
       service,
-      indexer([{ engagementId: 'eng1', amount: 100, balance: 100, flags: {} }])
-    );
-    const res = await svc.indexAll();
+      indexerWith([
+        { engagementId: 'eng1', amount: 100, balance: 100, flags: {} },
+      ]),
+      svc
+    ).indexAll();
     expect(res.indexed).toBe(1);
     expect(updates[0].match).toBe('eng1');
     expect(updates[0].payload.on_chain_status).toBe('funded');
-    expect(updates[0].payload.balance).toBe(100);
+  });
+
+  it('notifies once on a funded → released transition, before writing status', async () => {
+    const { service } = makeSupabase({
+      id: 'esc-1',
+      on_chain_status: 'funded',
+      buyer_id: 'b',
+      seller_id: 's',
+    });
+    const { svc, onEscrowReleased } = notifySpy();
+    await new EscrowIndexerService(
+      service,
+      indexerWith([
+        {
+          engagementId: 'eng1',
+          amount: 100,
+          balance: 100,
+          flags: { released: true },
+        },
+      ]),
+      svc
+    ).indexAll();
+    expect(onEscrowReleased).toHaveBeenCalledTimes(1);
+    expect(onEscrowReleased).toHaveBeenCalledWith({
+      escrowId: 'esc-1',
+      buyerId: 'b',
+      sellerId: 's',
+      engagementId: 'eng1',
+      amount: 100,
+    });
+  });
+
+  it('does NOT notify when already released (idempotent) or on baseline (no prior row)', async () => {
+    const already = makeSupabase({
+      id: 'esc-1',
+      on_chain_status: 'released',
+      buyer_id: 'b',
+      seller_id: 's',
+    });
+    const n1 = notifySpy();
+    await new EscrowIndexerService(
+      already.service,
+      indexerWith([
+        {
+          engagementId: 'eng1',
+          amount: 1,
+          balance: 1,
+          flags: { released: true },
+        },
+      ]),
+      n1.svc
+    ).indexAll();
+    expect(n1.onEscrowReleased).not.toHaveBeenCalled();
+
+    const missing = makeSupabase(null);
+    const n2 = notifySpy();
+    const res = await new EscrowIndexerService(
+      missing.service,
+      indexerWith([
+        {
+          engagementId: 'eng1',
+          amount: 1,
+          balance: 1,
+          flags: { released: true },
+        },
+      ]),
+      n2.svc
+    ).indexAll();
+    expect(n2.onEscrowReleased).not.toHaveBeenCalled();
+    expect(res.unmatched).toBe(1);
   });
 
   it('no-ops when TLW is not configured', async () => {
-    const { service } = makeSupabase();
+    const { service } = makeSupabase(null);
+    const { svc } = notifySpy();
     const notConfigured = {
       isConfigured: () => false,
       getPlatformEscrows: jest.fn(),
     } as unknown as TrustlessIndexerService;
     const res = await new EscrowIndexerService(
       service,
-      notConfigured
+      notConfigured,
+      svc
     ).indexAll();
     expect(res.indexed).toBe(0);
   });

--- a/apps/backend/src/domains/escrow/escrow-indexer.service.ts
+++ b/apps/backend/src/domains/escrow/escrow-indexer.service.ts
@@ -3,6 +3,9 @@ import { SupabaseService } from '@core/supabase/supabase.service';
 // biome-ignore lint/style/useImportType: required for NestJS dependency injection
 import { TrustlessIndexerService } from '@core/trustless/trustless-indexer.service';
 import { toEscrowPatch } from '@domains/escrow/escrow-mapper';
+import { detectEscrowTransition } from '@domains/notifications/escrow-transition';
+// biome-ignore lint/style/useImportType: required for NestJS dependency injection
+import { NotificationsService } from '@domains/notifications/notifications.service';
 import { Injectable, Logger } from '@nestjs/common';
 
 @Injectable()
@@ -11,7 +14,8 @@ export class EscrowIndexerService {
 
   constructor(
     private readonly supabase: SupabaseService,
-    private readonly indexer: TrustlessIndexerService
+    private readonly indexer: TrustlessIndexerService,
+    private readonly notifications: NotificationsService
   ) {}
 
   async indexAll(): Promise<{ indexed: number; unmatched: number }> {
@@ -30,6 +34,34 @@ export class EscrowIndexerService {
         continue;
       }
       const patch = toEscrowPatch(escrow, now);
+
+      // Read prior state to detect a transition (and to resolve the parties).
+      const { data: existing } = await this.supabase.client
+        .from('escrows')
+        .select('id, on_chain_status, buyer_id, seller_id')
+        .eq('engagement_id', escrow.engagementId)
+        .maybeSingle();
+      if (!existing) {
+        unmatched += 1;
+        continue; // web owns row creation; we only enrich existing rows
+      }
+
+      // Crash-safe: notify BEFORE writing the new status (re-index re-detects
+      // until the status write lands; NotificationsService dedups via UNIQUE).
+      const transition = detectEscrowTransition(
+        existing.on_chain_status,
+        patch.on_chain_status
+      );
+      if (transition?.kind === 'escrow_released') {
+        await this.notifications.onEscrowReleased({
+          escrowId: existing.id,
+          buyerId: existing.buyer_id,
+          sellerId: existing.seller_id,
+          engagementId: escrow.engagementId,
+          amount: patch.token_amount,
+        });
+      }
+
       const { error } = await this.supabase.client
         .from('escrows')
         .update({ ...patch, updated_at: new Date(now).toISOString() })

--- a/apps/backend/src/domains/escrow/escrow.module.ts
+++ b/apps/backend/src/domains/escrow/escrow.module.ts
@@ -2,9 +2,11 @@ import { EscrowController } from '@domains/escrow/escrow.controller';
 import { EscrowService } from '@domains/escrow/escrow.service';
 import { EscrowIndexCron } from '@domains/escrow/escrow-index.cron';
 import { EscrowIndexerService } from '@domains/escrow/escrow-indexer.service';
+import { NotificationsModule } from '@domains/notifications/notifications.module';
 import { Module } from '@nestjs/common';
 
 @Module({
+  imports: [NotificationsModule],
   controllers: [EscrowController],
   providers: [EscrowService, EscrowIndexerService, EscrowIndexCron],
 })

--- a/apps/backend/src/domains/notifications/escrow-transition.spec.ts
+++ b/apps/backend/src/domains/notifications/escrow-transition.spec.ts
@@ -1,0 +1,29 @@
+import { detectEscrowTransition } from '@domains/notifications/escrow-transition';
+
+describe('detectEscrowTransition', () => {
+  it('fires escrow_released on a non-released → released transition', () => {
+    expect(detectEscrowTransition('funded', 'released')).toEqual({
+      kind: 'escrow_released',
+    });
+    expect(detectEscrowTransition('active', 'released')).toEqual({
+      kind: 'escrow_released',
+    });
+    expect(detectEscrowTransition('disputed', 'released')).toEqual({
+      kind: 'escrow_released',
+    });
+  });
+
+  it('does NOT fire when already released (idempotent re-index)', () => {
+    expect(detectEscrowTransition('released', 'released')).toBeNull();
+  });
+
+  it('does NOT fire for non-released targets', () => {
+    expect(detectEscrowTransition('active', 'funded')).toBeNull();
+    expect(detectEscrowTransition('funded', 'disputed')).toBeNull();
+  });
+
+  it('anti-backfill: null/undefined prior status never fires (baseline)', () => {
+    expect(detectEscrowTransition(null, 'released')).toBeNull();
+    expect(detectEscrowTransition(undefined, 'released')).toBeNull();
+  });
+});

--- a/apps/backend/src/domains/notifications/escrow-transition.ts
+++ b/apps/backend/src/domains/notifications/escrow-transition.ts
@@ -1,0 +1,15 @@
+import type { TransitionEvent } from '@domains/notifications/notifications.types';
+
+export function detectEscrowTransition(
+  oldStatus: string | null | undefined,
+  newStatus: string
+): TransitionEvent | null {
+  // Anti-backfill: a never-indexed escrow (null prior) is treated as baseline.
+  if (oldStatus == null) {
+    return null;
+  }
+  if (oldStatus !== 'released' && newStatus === 'released') {
+    return { kind: 'escrow_released' };
+  }
+  return null;
+}

--- a/apps/backend/src/domains/notifications/notification-builder.spec.ts
+++ b/apps/backend/src/domains/notifications/notification-builder.spec.ts
@@ -1,0 +1,25 @@
+import { buildReleasedNotifications } from '@domains/notifications/notification-builder';
+
+const input = {
+  escrowId: 'esc-1',
+  buyerId: 'buyer-1',
+  sellerId: 'seller-1',
+  engagementId: 'eng-1',
+  amount: 250,
+};
+
+describe('buildReleasedNotifications', () => {
+  it('produces one draft per party with role-aware data', () => {
+    const drafts = buildReleasedNotifications(input);
+    expect(drafts).toHaveLength(2);
+    const buyer = drafts.find((d) => d.user_id === 'buyer-1');
+    const seller = drafts.find((d) => d.user_id === 'seller-1');
+    expect(buyer?.type).toBe('escrow_released');
+    expect(buyer?.escrow_id).toBe('esc-1');
+    expect(buyer?.data.role).toBe('buyer');
+    expect(buyer?.data.counterparty_id).toBe('seller-1');
+    expect(seller?.data.role).toBe('seller');
+    expect(seller?.data.engagement_id).toBe('eng-1');
+    expect(seller?.body).not.toEqual(buyer?.body);
+  });
+});

--- a/apps/backend/src/domains/notifications/notification-builder.ts
+++ b/apps/backend/src/domains/notifications/notification-builder.ts
@@ -1,0 +1,37 @@
+import type {
+  EscrowReleasedInput,
+  NotificationDraft,
+} from '@domains/notifications/notifications.types';
+
+export function buildReleasedNotifications(
+  input: EscrowReleasedInput
+): NotificationDraft[] {
+  const { escrowId, buyerId, sellerId, engagementId, amount } = input;
+  const common = { type: 'escrow_released' as const, escrow_id: escrowId };
+  return [
+    {
+      ...common,
+      user_id: buyerId,
+      title: 'Fondos liberados',
+      body: `Los fondos de tu escrow ${engagementId} fueron liberados al vendedor.`,
+      data: {
+        engagement_id: engagementId,
+        amount,
+        role: 'buyer',
+        counterparty_id: sellerId,
+      },
+    },
+    {
+      ...common,
+      user_id: sellerId,
+      title: 'Recibiste la liberación de fondos',
+      body: `Se liberaron los fondos del escrow ${engagementId}. La operación se completó.`,
+      data: {
+        engagement_id: engagementId,
+        amount,
+        role: 'seller',
+        counterparty_id: buyerId,
+      },
+    },
+  ];
+}

--- a/apps/backend/src/domains/notifications/notification-prefs.spec.ts
+++ b/apps/backend/src/domains/notifications/notification-prefs.spec.ts
@@ -1,0 +1,25 @@
+import { normalizeNotifications } from '@domains/notifications/notification-prefs';
+
+describe('normalizeNotifications', () => {
+  it('defaults to email on / sms off for empty input', () => {
+    expect(normalizeNotifications(null)).toEqual({
+      email_trades: true,
+      email_escrows: true,
+      push_notifications: true,
+      sms_notifications: false,
+    });
+  });
+
+  it('reads canonical fields', () => {
+    const p = normalizeNotifications({ email_escrows: false });
+    expect(p.email_escrows).toBe(false);
+    expect(p.email_trades).toBe(true);
+  });
+
+  it('maps legacy { email, push } shape', () => {
+    const p = normalizeNotifications({ email: false, push: false });
+    expect(p.email_escrows).toBe(false);
+    expect(p.email_trades).toBe(false);
+    expect(p.push_notifications).toBe(false);
+  });
+});

--- a/apps/backend/src/domains/notifications/notification-prefs.ts
+++ b/apps/backend/src/domains/notifications/notification-prefs.ts
@@ -1,0 +1,19 @@
+import type { NotificationPrefs } from '@domains/notifications/notifications.types';
+
+export function normalizeNotifications(value: unknown): NotificationPrefs {
+  if (!value || typeof value !== 'object') {
+    return {
+      email_trades: true,
+      email_escrows: true,
+      push_notifications: true,
+      sms_notifications: false,
+    };
+  }
+  const o = value as Record<string, unknown>;
+  return {
+    email_trades: Boolean(o.email_trades ?? o.email ?? true),
+    email_escrows: Boolean(o.email_escrows ?? o.email ?? true),
+    push_notifications: Boolean(o.push_notifications ?? o.push ?? true),
+    sms_notifications: Boolean(o.sms_notifications ?? o.sms ?? false),
+  };
+}

--- a/apps/backend/src/domains/notifications/notifications.controller.ts
+++ b/apps/backend/src/domains/notifications/notifications.controller.ts
@@ -1,0 +1,41 @@
+// biome-ignore lint/style/useImportType: required for NestJS dependency injection
+import { NotificationsService } from '@domains/notifications/notifications.service';
+import {
+  Controller,
+  Get,
+  Param,
+  ParseUUIDPipe,
+  Patch,
+  Query,
+} from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+
+@ApiTags('notifications')
+@Controller()
+export class NotificationsController {
+  constructor(private readonly notifications: NotificationsService) {}
+
+  @Get('notifications/users/:id')
+  @ApiOperation({
+    summary: 'Recent notifications for a user (most recent first).',
+  })
+  async forUser(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Query('limit') limit?: string
+  ) {
+    const max = Math.min(Math.max(Number(limit) || 50, 1), 200);
+    return { notifications: await this.notifications.listForUser(id, max) };
+  }
+
+  @Get('notifications/users/:id/unread-count')
+  @ApiOperation({ summary: 'Count of unread notifications for a user.' })
+  async unreadCount(@Param('id', ParseUUIDPipe) id: string) {
+    return { count: await this.notifications.unreadCount(id) };
+  }
+
+  @Patch('notifications/:id/read')
+  @ApiOperation({ summary: 'Mark a notification as read.' })
+  async markRead(@Param('id', ParseUUIDPipe) id: string) {
+    return { notification: await this.notifications.markRead(id) };
+  }
+}

--- a/apps/backend/src/domains/notifications/notifications.module.ts
+++ b/apps/backend/src/domains/notifications/notifications.module.ts
@@ -1,0 +1,10 @@
+import { NotificationsController } from '@domains/notifications/notifications.controller';
+import { NotificationsService } from '@domains/notifications/notifications.service';
+import { Module } from '@nestjs/common';
+
+@Module({
+  controllers: [NotificationsController],
+  providers: [NotificationsService],
+  exports: [NotificationsService],
+})
+export class NotificationsModule {}

--- a/apps/backend/src/domains/notifications/notifications.service.spec.ts
+++ b/apps/backend/src/domains/notifications/notifications.service.spec.ts
@@ -1,0 +1,118 @@
+import type { EmailService } from '@core/email/email.service';
+import type { SupabaseService } from '@core/supabase/supabase.service';
+import { NotificationsService } from '@domains/notifications/notifications.service';
+
+// Chainable Supabase mock: notifications upsert(...).select('id') resolves via then();
+// notifications update(...).eq() resolves via then(); users select(...).eq().maybeSingle() resolves the user.
+function makeSupabase(opts: { user?: any; existing?: boolean }) {
+  const inserted: any[] = [];
+  const updates: any[] = [];
+  const client = {
+    from(table: string) {
+      const b: any = {
+        _op: null as null | 'upsert' | 'update',
+        _payload: null as any,
+        upsert(payload: any) {
+          b._op = 'upsert';
+          b._payload = payload;
+          return b;
+        },
+        update(payload: any) {
+          b._op = 'update';
+          b._payload = payload;
+          return b;
+        },
+        select() {
+          return b;
+        },
+        eq() {
+          return b;
+        },
+        maybeSingle() {
+          return Promise.resolve({ data: opts.user ?? null, error: null });
+        },
+        // biome-ignore lint/suspicious/noThenProperty: intentional thenable to mimic Supabase's chainable builder
+        then(resolve: any) {
+          if (table === 'notifications' && b._op === 'upsert') {
+            inserted.push(b._payload);
+            const data = opts.existing ? [] : [{ id: `n-${inserted.length}` }];
+            return Promise.resolve({ data, error: null }).then(resolve);
+          }
+          if (table === 'notifications' && b._op === 'update') {
+            updates.push(b._payload);
+            return Promise.resolve({ data: null, error: null }).then(resolve);
+          }
+          return Promise.resolve({ data: null, error: null }).then(resolve);
+        },
+      };
+      return b;
+    },
+  };
+  return {
+    service: { client } as unknown as SupabaseService,
+    inserted,
+    updates,
+  };
+}
+
+const input = {
+  escrowId: 'esc-1',
+  buyerId: 'buyer-1',
+  sellerId: 'seller-1',
+  engagementId: 'eng-1',
+  amount: 250,
+};
+
+describe('NotificationsService.onEscrowReleased', () => {
+  it('inserts a row per party with email skipped when channel disabled', async () => {
+    const { service, inserted, updates } = makeSupabase({ existing: false });
+    const email = {
+      isEnabled: () => false,
+      send: jest.fn(),
+    } as unknown as EmailService;
+    await new NotificationsService(service, email).onEscrowReleased(input);
+    expect(inserted).toHaveLength(2);
+    expect(inserted[0].email_status).toBe('pending');
+    expect(updates.every((u) => u.email_status === 'skipped')).toBe(true);
+    expect(email.send as jest.Mock).not.toHaveBeenCalled();
+  });
+
+  it('does not resend email for an already-existing row (dedup)', async () => {
+    const { service, updates } = makeSupabase({ existing: true });
+    const email = {
+      isEnabled: () => true,
+      send: jest.fn(),
+    } as unknown as EmailService;
+    await new NotificationsService(service, email).onEscrowReleased(input);
+    expect(email.send as jest.Mock).not.toHaveBeenCalled();
+    expect(updates).toHaveLength(0);
+  });
+
+  it('sends email and marks sent when enabled and pref on', async () => {
+    const { service, updates } = makeSupabase({
+      existing: false,
+      user: {
+        email: 'a@b.com',
+        full_name: 'Alice',
+        notifications: { email_escrows: true },
+      },
+    });
+    const send = jest.fn().mockResolvedValue({ status: 'sent' });
+    const email = { isEnabled: () => true, send } as unknown as EmailService;
+    await new NotificationsService(service, email).onEscrowReleased(input);
+    expect(send).toHaveBeenCalledTimes(2);
+    expect(updates.every((u) => u.email_status === 'sent')).toBe(true);
+  });
+
+  it('skips email when pref email_escrows is off', async () => {
+    const { service, updates } = makeSupabase({
+      existing: false,
+      user: { email: 'a@b.com', notifications: { email_escrows: false } },
+    });
+    const send = jest.fn();
+    const email = { isEnabled: () => true, send } as unknown as EmailService;
+    await new NotificationsService(service, email).onEscrowReleased(input);
+    expect(send).not.toHaveBeenCalled();
+    expect(updates.every((u) => u.email_status === 'skipped')).toBe(true);
+  });
+});

--- a/apps/backend/src/domains/notifications/notifications.service.ts
+++ b/apps/backend/src/domains/notifications/notifications.service.ts
@@ -1,0 +1,138 @@
+// biome-ignore lint/style/useImportType: required for NestJS dependency injection
+import { EmailService } from '@core/email/email.service';
+import { renderEscrowReleasedEmail } from '@core/email/templates/escrow-released.template';
+// biome-ignore lint/style/useImportType: required for NestJS dependency injection
+import { SupabaseService } from '@core/supabase/supabase.service';
+import { buildReleasedNotifications } from '@domains/notifications/notification-builder';
+import { normalizeNotifications } from '@domains/notifications/notification-prefs';
+import type {
+  EmailStatus,
+  EscrowReleasedInput,
+  NotificationDraft,
+} from '@domains/notifications/notifications.types';
+import { Injectable, Logger } from '@nestjs/common';
+
+@Injectable()
+export class NotificationsService {
+  private readonly logger = new Logger(NotificationsService.name);
+
+  constructor(
+    private readonly supabase: SupabaseService,
+    private readonly email: EmailService
+  ) {}
+
+  async onEscrowReleased(input: EscrowReleasedInput): Promise<void> {
+    for (const draft of buildReleasedNotifications(input)) {
+      try {
+        await this.deliver(draft, input);
+      } catch (err) {
+        this.logger.error(
+          `notify ${draft.user_id} failed: ${(err as Error).message}`
+        );
+      }
+    }
+  }
+
+  private async deliver(
+    draft: NotificationDraft,
+    input: EscrowReleasedInput
+  ): Promise<void> {
+    // Insert first (idempotent). New row → [{id}]; existing → [] (already delivered).
+    const { data: rows, error } = await this.supabase.client
+      .from('notifications')
+      .upsert(
+        { ...draft, email_status: 'pending' as EmailStatus },
+        { onConflict: 'user_id,type,escrow_id', ignoreDuplicates: true }
+      )
+      .select('id');
+    if (error) {
+      this.logger.error(`insert notification failed: ${error.message}`);
+      return;
+    }
+    const row = Array.isArray(rows) ? rows[0] : null;
+    if (!row) {
+      return; // already delivered previously — do not resend
+    }
+
+    const status = await this.resolveEmail(draft, input);
+    await this.supabase.client
+      .from('notifications')
+      .update({ email_status: status })
+      .eq('id', row.id);
+  }
+
+  private async resolveEmail(
+    draft: NotificationDraft,
+    input: EscrowReleasedInput
+  ): Promise<EmailStatus> {
+    if (!this.email.isEnabled()) {
+      return 'skipped';
+    }
+    const { data: user } = await this.supabase.client
+      .from('users')
+      .select('email, full_name, notifications')
+      .eq('id', draft.user_id)
+      .maybeSingle();
+    if (!user?.email) {
+      return 'skipped';
+    }
+    if (!normalizeNotifications(user.notifications).email_escrows) {
+      return 'skipped';
+    }
+    const role = draft.data.role === 'seller' ? 'seller' : 'buyer';
+    const rendered = renderEscrowReleasedEmail({
+      recipientName: user.full_name ?? undefined,
+      role,
+      engagementId: input.engagementId,
+      amount: input.amount,
+    });
+    const { status } = await this.email.send({ to: user.email, ...rendered });
+    return status;
+  }
+
+  async listForUser(userId: string, limit: number): Promise<unknown[]> {
+    const { data, error } = await this.supabase.client
+      .from('notifications')
+      .select(
+        'id, type, escrow_id, title, body, data, read_at, email_status, created_at'
+      )
+      .eq('user_id', userId)
+      .order('created_at', { ascending: false })
+      .limit(limit);
+    if (error) {
+      throw new Error(
+        `Failed to load notifications for ${userId}: ${error.message}`
+      );
+    }
+    return data ?? [];
+  }
+
+  async unreadCount(userId: string): Promise<number> {
+    const { count, error } = await this.supabase.client
+      .from('notifications')
+      .select('id', { count: 'exact', head: true })
+      .eq('user_id', userId)
+      .is('read_at', null);
+    if (error) {
+      throw new Error(
+        `Failed to count notifications for ${userId}: ${error.message}`
+      );
+    }
+    return count ?? 0;
+  }
+
+  async markRead(id: string): Promise<unknown> {
+    const { data, error } = await this.supabase.client
+      .from('notifications')
+      .update({ read_at: new Date().toISOString() })
+      .eq('id', id)
+      .select('id, read_at')
+      .maybeSingle();
+    if (error) {
+      throw new Error(
+        `Failed to mark notification ${id} read: ${error.message}`
+      );
+    }
+    return data;
+  }
+}

--- a/apps/backend/src/domains/notifications/notifications.service.ts
+++ b/apps/backend/src/domains/notifications/notifications.service.ts
@@ -55,10 +55,15 @@ export class NotificationsService {
     }
 
     const status = await this.resolveEmail(draft, input);
-    await this.supabase.client
+    const { error: updErr } = await this.supabase.client
       .from('notifications')
       .update({ email_status: status })
       .eq('id', row.id);
+    if (updErr) {
+      this.logger.error(
+        `update email_status for ${row.id} failed: ${updErr.message}`
+      );
+    }
   }
 
   private async resolveEmail(

--- a/apps/backend/src/domains/notifications/notifications.types.ts
+++ b/apps/backend/src/domains/notifications/notifications.types.ts
@@ -1,0 +1,31 @@
+export type NotificationType = 'escrow_released';
+
+export type EmailStatus = 'pending' | 'sent' | 'failed' | 'skipped';
+
+export interface NotificationPrefs {
+  email_trades: boolean;
+  email_escrows: boolean;
+  push_notifications: boolean;
+  sms_notifications: boolean;
+}
+
+export interface NotificationDraft {
+  user_id: string;
+  type: NotificationType;
+  escrow_id: string;
+  title: string;
+  body: string;
+  data: Record<string, unknown>;
+}
+
+export interface EscrowReleasedInput {
+  escrowId: string;
+  buyerId: string;
+  sellerId: string;
+  engagementId: string;
+  amount: number;
+}
+
+export interface TransitionEvent {
+  kind: NotificationType;
+}

--- a/docs/superpowers/plans/2026-06-27-backend-notifications-phase5.md
+++ b/docs/superpowers/plans/2026-06-27-backend-notifications-phase5.md
@@ -1,0 +1,1240 @@
+# Backend Phase 5 — Notification Service Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When the escrow indexer detects an escrow transition to `released`, persist in-app notification rows (one per party) to a new `notifications` table and optionally send an email via Resend — with the email channel **disabled by default** (empty `RESEND_API_KEY`). Expose a read API for the rows.
+
+**Architecture:** A `core/email` module wraps Resend behind `isEnabled()`/`send()` (no-op when unconfigured). A new `domains/notifications` context holds pure helpers (`detectEscrowTransition`, `normalizeNotifications`, `buildReleasedNotifications`), a `NotificationsService` that inserts rows (idempotent via a UNIQUE constraint) and conditionally emails, a read controller, and the module. The escrow indexer is changed from a blind upsert to **read-before-write**: it reads the prior `on_chain_status`, detects a `→released` transition, calls `NotificationsService.onEscrowReleased(...)` **before** writing the new status (crash-safe), and the UNIQUE constraint dedups. Flow is one-way Escrow → Notifications.
+
+**Tech Stack:** NestJS 11, `resend` (npm), `@supabase/supabase-js` (service role), `@nestjs/config` (Joi), `@pacto-p2p/types` (`Escrow`), Jest.
+
+**Spec:** `docs/superpowers/specs/2026-06-27-backend-notifications-phase5-design.md`
+**Branch:** `feat/139-notifications` (stacked on `feat/138a-escrow-indexing` — escrow indexing provides the state the events derive from).
+**Build hygiene:** `rm -rf apps/backend/dist apps/backend/*.tsbuildinfo` before backend builds; run from `apps/backend`.
+**DI footgun:** injected deps (`ConfigService`, `SupabaseService`, `EmailService`, `NotificationsService`, `EscrowIndexerService`) are VALUE imports with `// biome-ignore lint/style/useImportType: required for NestJS dependency injection`. Pure-helper types stay `import type`.
+**Git/PR:** NO `Co-Authored-By`, NO "Generated with Claude" footer. PR to `PACTO-LAT/pacto-p2p` base `develop`, gh account `aguilar1x`.
+
+---
+
+## File map
+
+| File | Responsibility |
+|---|---|
+| `supabase/migrations/20260627120000_create_notifications.sql` | `notifications` table + unique/idx |
+| `apps/backend/src/config/env.validation.ts` (mod), `.env.example` (mod) | `RESEND_API_KEY`, `EMAIL_FROM` |
+| `apps/backend/package.json` (mod) | add `resend` dep |
+| `apps/backend/src/core/email/email.config.ts` | reserved typed accessors (optional, inline ok) |
+| `.../core/email/email.service.ts` (+ `.spec.ts`) | `isEnabled()` + `send()` (skipped when off) |
+| `.../core/email/templates/escrow-released.template.ts` (+ `.spec.ts`) | pure `renderEscrowReleasedEmail` |
+| `.../core/email/email.module.ts` | `@Global` provides/exports `EmailService` |
+| `apps/backend/src/core/core.module.ts` (mod) | import `EmailModule` |
+| `apps/backend/src/domains/notifications/notifications.types.ts` | shared types |
+| `.../notifications/escrow-transition.ts` (+ `.spec.ts`) | pure `detectEscrowTransition` |
+| `.../notifications/notification-prefs.ts` (+ `.spec.ts`) | pure `normalizeNotifications` |
+| `.../notifications/notification-builder.ts` (+ `.spec.ts`) | pure `buildReleasedNotifications` |
+| `.../notifications/notifications.service.ts` (+ `.spec.ts`) | insert rows + conditional email |
+| `.../notifications/notifications.controller.ts` | `GET`/`PATCH /v1/notifications...` |
+| `.../notifications/notifications.module.ts` | wires service+controller, exports service |
+| `.../domains/escrow/escrow-indexer.service.ts` (mod, + spec mod) | read-before-write + notify |
+| `.../domains/escrow/escrow.module.ts` (mod) | import `NotificationsModule` |
+
+---
+
+## Task 1: Migration + email env + `resend` dependency
+
+**Files:**
+- Create: `supabase/migrations/20260627120000_create_notifications.sql`
+- Modify: `apps/backend/src/config/env.validation.ts`, `apps/backend/.env.example`, `apps/backend/package.json`
+
+- [ ] **Step 1: Create the migration**
+
+```sql
+-- Persist in-app notifications. email_status tracks the optional email channel.
+CREATE TABLE IF NOT EXISTS notifications (
+  id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id      UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  type         TEXT NOT NULL,
+  escrow_id    UUID REFERENCES escrows(id) ON DELETE CASCADE,
+  title        TEXT NOT NULL,
+  body         TEXT NOT NULL,
+  data         JSONB NOT NULL DEFAULT '{}'::jsonb,
+  read_at      TIMESTAMPTZ,
+  email_status TEXT NOT NULL DEFAULT 'skipped',
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_notifications_user_type_escrow
+  ON notifications(user_id, type, escrow_id);
+CREATE INDEX IF NOT EXISTS idx_notifications_user_created
+  ON notifications(user_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_notifications_email_pending
+  ON notifications(email_status) WHERE email_status = 'pending';
+
+ALTER TABLE notifications ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS notifications_select_own ON notifications;
+CREATE POLICY notifications_select_own ON notifications FOR SELECT
+  USING (auth.uid() = user_id);
+```
+Confirm the filename sorts last: `ls supabase/migrations | sort | tail -3`. Do NOT apply to remote here (Task 6 applies it to dev). The backend uses the service-role client, which bypasses RLS — the policy is for parity/defense-in-depth.
+
+- [ ] **Step 2: Add email env to `apps/backend/src/config/env.validation.ts`**
+
+Inside the `Joi.object({ ... })`, after `ESCROW_INDEX_CRON`, add:
+```ts
+  RESEND_API_KEY: Joi.string().allow('').default(''),
+  EMAIL_FROM: Joi.string().default('Pacto <no-reply@pacto.app>'),
+```
+(`RESEND_API_KEY` empty → email channel disabled; missing config is feature-flag-off, not a boot failure.)
+
+- [ ] **Step 3: Document them in `apps/backend/.env.example`**
+
+Append:
+```dotenv
+
+# Email notifications via Resend (leave RESEND_API_KEY empty to disable email; in-app notifications still work)
+RESEND_API_KEY=
+EMAIL_FROM=Pacto <no-reply@pacto.app>
+```
+
+- [ ] **Step 4: Add the `resend` dependency**
+
+Run (matches the web's `resend@^4.8.0`):
+```bash
+cd apps/backend && npm install resend@^4.8.0 && cd ../..
+```
+Expected: `resend` appears in `apps/backend/package.json` dependencies; lockfile updated.
+
+- [ ] **Step 5: Verify build**
+
+```bash
+cd apps/backend && npm run biome:fix && npm run biome:check && cd ../..
+npm run type-check
+rm -rf apps/backend/dist apps/backend/*.tsbuildinfo && (cd apps/backend && npm run build)
+```
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add supabase/migrations/20260627120000_create_notifications.sql apps/backend/src/config/env.validation.ts apps/backend/.env.example apps/backend/package.json package-lock.json
+git commit -m "feat(backend): add notifications table + email env + resend dep (#139)"
+```
+
+---
+
+## Task 2: `core/email` module (disabled by default)
+
+**Files:**
+- Create: `apps/backend/src/core/email/templates/escrow-released.template.ts`, `escrow-released.template.spec.ts`, `email.service.ts`, `email.service.spec.ts`, `email.module.ts`
+- Modify: `apps/backend/src/core/core.module.ts`
+
+- [ ] **Step 1: Write `escrow-released.template.spec.ts` (failing)**
+
+```ts
+import { renderEscrowReleasedEmail } from '@core/email/templates/escrow-released.template';
+
+describe('renderEscrowReleasedEmail', () => {
+  it('produces subject/text/html and greets by name when provided', () => {
+    const out = renderEscrowReleasedEmail({
+      recipientName: 'Alice',
+      role: 'buyer',
+      engagementId: 'eng1',
+      amount: 250,
+    });
+    expect(out.subject).toMatch(/liberad/i);
+    expect(out.text).toContain('Alice');
+    expect(out.text).toContain('eng1');
+    expect(out.html).toContain('eng1');
+  });
+
+  it('uses seller copy and a generic greeting without a name', () => {
+    const buyer = renderEscrowReleasedEmail({ role: 'buyer', engagementId: 'e', amount: 1 });
+    const seller = renderEscrowReleasedEmail({ role: 'seller', engagementId: 'e', amount: 1 });
+    expect(seller.text).not.toEqual(buyer.text);
+    expect(seller.text).toContain('Hola,');
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd apps/backend && npm test -- escrow-released.template`
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Implement `escrow-released.template.ts`**
+
+```ts
+export interface EscrowReleasedEmailData {
+  recipientName?: string;
+  role: 'buyer' | 'seller';
+  engagementId: string;
+  amount: number;
+}
+
+export interface RenderedEmail {
+  subject: string;
+  html: string;
+  text: string;
+}
+
+export function renderEscrowReleasedEmail(
+  data: EscrowReleasedEmailData
+): RenderedEmail {
+  const greeting = data.recipientName ? `Hola ${data.recipientName},` : 'Hola,';
+  const line =
+    data.role === 'buyer'
+      ? `Los fondos de tu escrow ${data.engagementId} fueron liberados al vendedor.`
+      : `Se liberaron los fondos del escrow ${data.engagementId}. La operación se completó.`;
+  const subject = 'Pacto — Fondos liberados';
+  const text = `${greeting}\n\n${line}\n\nMonto: ${data.amount}\n\n— Pacto`;
+  const html = `<div style="font-family:sans-serif;color:#111">
+  <p>${greeting}</p>
+  <p>${line}</p>
+  <p><strong>Monto:</strong> ${data.amount}</p>
+  <p style="color:#059669">— Pacto</p>
+</div>`;
+  return { subject, html, text };
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd apps/backend && npm test -- escrow-released.template`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Write `email.service.spec.ts` (disabled path makes no network call)**
+
+```ts
+import { EmailService } from '@core/email/email.service';
+import type { ConfigService } from '@nestjs/config';
+
+function cfg(values: Record<string, string>): ConfigService {
+  return {
+    get: <T>(k: string, d?: T) => (values[k] as unknown as T) ?? d,
+  } as unknown as ConfigService;
+}
+
+describe('EmailService', () => {
+  const ORIGINAL_FETCH = global.fetch;
+  afterEach(() => {
+    global.fetch = ORIGINAL_FETCH;
+    jest.restoreAllMocks();
+  });
+
+  it('isEnabled is false when RESEND_API_KEY is empty', () => {
+    expect(new EmailService(cfg({})).isEnabled()).toBe(false);
+    expect(new EmailService(cfg({ RESEND_API_KEY: 're_x' })).isEnabled()).toBe(true);
+  });
+
+  it('send returns skipped and makes NO network call when disabled', async () => {
+    const fetchMock = jest.fn();
+    global.fetch = fetchMock as unknown as typeof fetch;
+    const svc = new EmailService(cfg({}));
+    const res = await svc.send({ to: 'a@b.com', subject: 's', html: '<p>x</p>', text: 'x' });
+    expect(res.status).toBe('skipped');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 6: Implement `email.service.ts`**
+
+```ts
+import { Injectable, Logger } from '@nestjs/common';
+// biome-ignore lint/style/useImportType: required for NestJS dependency injection
+import { ConfigService } from '@nestjs/config';
+import { Resend } from 'resend';
+
+export interface SendEmailInput {
+  to: string;
+  subject: string;
+  html: string;
+  text: string;
+}
+
+export type EmailSendStatus = 'sent' | 'failed' | 'skipped';
+
+@Injectable()
+export class EmailService {
+  private readonly logger = new Logger(EmailService.name);
+
+  constructor(private readonly config: ConfigService) {}
+
+  isEnabled(): boolean {
+    return !!this.config.get<string>('RESEND_API_KEY');
+  }
+
+  async send(input: SendEmailInput): Promise<{ status: EmailSendStatus }> {
+    const apiKey = this.config.get<string>('RESEND_API_KEY', '');
+    if (!apiKey) {
+      return { status: 'skipped' };
+    }
+    const from = this.config.get<string>(
+      'EMAIL_FROM',
+      'Pacto <no-reply@pacto.app>'
+    );
+    try {
+      const resend = new Resend(apiKey);
+      const { error } = await resend.emails.send({
+        from,
+        to: input.to,
+        subject: input.subject,
+        html: input.html,
+        text: input.text,
+      });
+      if (error) {
+        this.logger.error(`email send failed: ${error.message}`);
+        return { status: 'failed' };
+      }
+      return { status: 'sent' };
+    } catch (err) {
+      this.logger.error(`email send threw: ${(err as Error).message}`);
+      return { status: 'failed' };
+    }
+  }
+}
+```
+
+- [ ] **Step 7: Run the test**
+
+Run: `cd apps/backend && npm test -- email.service`
+Expected: PASS (2 tests).
+
+- [ ] **Step 8: Create `email.module.ts`**
+
+```ts
+import { EmailService } from '@core/email/email.service';
+import { Global, Module } from '@nestjs/common';
+
+@Global()
+@Module({
+  providers: [EmailService],
+  exports: [EmailService],
+})
+export class EmailModule {}
+```
+
+- [ ] **Step 9: Import `EmailModule` in `apps/backend/src/core/core.module.ts`**
+
+Add `import { EmailModule } from '@core/email/email.module';` and add `EmailModule` to the `imports` array (alongside `SupabaseModule`, `HealthModule`, `TrustlessModule`).
+
+- [ ] **Step 10: Biome + type-check + commit**
+
+```bash
+cd apps/backend && npm run biome:fix && npm run biome:check && cd ../..
+npm run type-check
+git add apps/backend/src/core/email apps/backend/src/core/core.module.ts
+git commit -m "feat(backend): add core/email module (Resend, disabled by default) (#139)"
+```
+
+---
+
+## Task 3: Pure helpers (TDD) — transition, prefs, builder, types
+
+**Files:**
+- Create: `apps/backend/src/domains/notifications/notifications.types.ts`, `escrow-transition.ts`, `escrow-transition.spec.ts`, `notification-prefs.ts`, `notification-prefs.spec.ts`, `notification-builder.ts`, `notification-builder.spec.ts`
+
+- [ ] **Step 1: Create `notifications.types.ts`**
+
+```ts
+export type NotificationType = 'escrow_released';
+
+export type EmailStatus = 'pending' | 'sent' | 'failed' | 'skipped';
+
+export interface NotificationPrefs {
+  email_trades: boolean;
+  email_escrows: boolean;
+  push_notifications: boolean;
+  sms_notifications: boolean;
+}
+
+export interface NotificationDraft {
+  user_id: string;
+  type: NotificationType;
+  escrow_id: string;
+  title: string;
+  body: string;
+  data: Record<string, unknown>;
+}
+
+export interface EscrowReleasedInput {
+  escrowId: string;
+  buyerId: string;
+  sellerId: string;
+  engagementId: string;
+  amount: number;
+}
+
+export interface TransitionEvent {
+  kind: NotificationType;
+}
+```
+
+- [ ] **Step 2: Write `escrow-transition.spec.ts` (failing)**
+
+```ts
+import { detectEscrowTransition } from '@domains/notifications/escrow-transition';
+
+describe('detectEscrowTransition', () => {
+  it('fires escrow_released on a non-released → released transition', () => {
+    expect(detectEscrowTransition('funded', 'released')).toEqual({ kind: 'escrow_released' });
+    expect(detectEscrowTransition('active', 'released')).toEqual({ kind: 'escrow_released' });
+    expect(detectEscrowTransition('disputed', 'released')).toEqual({ kind: 'escrow_released' });
+  });
+
+  it('does NOT fire when already released (idempotent re-index)', () => {
+    expect(detectEscrowTransition('released', 'released')).toBeNull();
+  });
+
+  it('does NOT fire for non-released targets', () => {
+    expect(detectEscrowTransition('active', 'funded')).toBeNull();
+    expect(detectEscrowTransition('funded', 'disputed')).toBeNull();
+  });
+
+  it('anti-backfill: null/undefined prior status never fires (baseline)', () => {
+    expect(detectEscrowTransition(null, 'released')).toBeNull();
+    expect(detectEscrowTransition(undefined, 'released')).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 3: Run to verify it fails**
+
+Run: `cd apps/backend && npm test -- escrow-transition`
+Expected: FAIL (module not found).
+
+- [ ] **Step 4: Implement `escrow-transition.ts`**
+
+```ts
+import type { TransitionEvent } from '@domains/notifications/notifications.types';
+
+export function detectEscrowTransition(
+  oldStatus: string | null | undefined,
+  newStatus: string
+): TransitionEvent | null {
+  // Anti-backfill: a never-indexed escrow (null prior) is treated as baseline.
+  if (oldStatus == null) {
+    return null;
+  }
+  if (oldStatus !== 'released' && newStatus === 'released') {
+    return { kind: 'escrow_released' };
+  }
+  return null;
+}
+```
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `cd apps/backend && npm test -- escrow-transition`
+Expected: PASS (4 tests).
+
+- [ ] **Step 6: Write `notification-prefs.spec.ts` (failing)**
+
+```ts
+import { normalizeNotifications } from '@domains/notifications/notification-prefs';
+
+describe('normalizeNotifications', () => {
+  it('defaults to email on / sms off for empty input', () => {
+    expect(normalizeNotifications(null)).toEqual({
+      email_trades: true,
+      email_escrows: true,
+      push_notifications: true,
+      sms_notifications: false,
+    });
+  });
+
+  it('reads canonical fields', () => {
+    const p = normalizeNotifications({ email_escrows: false });
+    expect(p.email_escrows).toBe(false);
+    expect(p.email_trades).toBe(true);
+  });
+
+  it('maps legacy { email, push } shape', () => {
+    const p = normalizeNotifications({ email: false, push: false });
+    expect(p.email_escrows).toBe(false);
+    expect(p.email_trades).toBe(false);
+    expect(p.push_notifications).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 7: Run to verify it fails**
+
+Run: `cd apps/backend && npm test -- notification-prefs`
+Expected: FAIL (module not found).
+
+- [ ] **Step 8: Implement `notification-prefs.ts`** (ported from `apps/web/lib/utils/normalize-user.ts`)
+
+```ts
+import type { NotificationPrefs } from '@domains/notifications/notifications.types';
+
+export function normalizeNotifications(value: unknown): NotificationPrefs {
+  if (!value || typeof value !== 'object') {
+    return {
+      email_trades: true,
+      email_escrows: true,
+      push_notifications: true,
+      sms_notifications: false,
+    };
+  }
+  const o = value as Record<string, unknown>;
+  return {
+    email_trades: Boolean(o.email_trades ?? o.email ?? true),
+    email_escrows: Boolean(o.email_escrows ?? o.email ?? true),
+    push_notifications: Boolean(o.push_notifications ?? o.push ?? true),
+    sms_notifications: Boolean(o.sms_notifications ?? o.sms ?? false),
+  };
+}
+```
+
+- [ ] **Step 9: Run to verify it passes**
+
+Run: `cd apps/backend && npm test -- notification-prefs`
+Expected: PASS (3 tests).
+
+- [ ] **Step 10: Write `notification-builder.spec.ts` (failing)**
+
+```ts
+import { buildReleasedNotifications } from '@domains/notifications/notification-builder';
+
+const input = {
+  escrowId: 'esc-1',
+  buyerId: 'buyer-1',
+  sellerId: 'seller-1',
+  engagementId: 'eng-1',
+  amount: 250,
+};
+
+describe('buildReleasedNotifications', () => {
+  it('produces one draft per party with role-aware data', () => {
+    const drafts = buildReleasedNotifications(input);
+    expect(drafts).toHaveLength(2);
+    const buyer = drafts.find((d) => d.user_id === 'buyer-1');
+    const seller = drafts.find((d) => d.user_id === 'seller-1');
+    expect(buyer?.type).toBe('escrow_released');
+    expect(buyer?.escrow_id).toBe('esc-1');
+    expect(buyer?.data.role).toBe('buyer');
+    expect(buyer?.data.counterparty_id).toBe('seller-1');
+    expect(seller?.data.role).toBe('seller');
+    expect(seller?.data.engagement_id).toBe('eng-1');
+    expect(seller?.body).not.toEqual(buyer?.body);
+  });
+});
+```
+
+- [ ] **Step 11: Run to verify it fails**
+
+Run: `cd apps/backend && npm test -- notification-builder`
+Expected: FAIL (module not found).
+
+- [ ] **Step 12: Implement `notification-builder.ts`**
+
+```ts
+import type {
+  EscrowReleasedInput,
+  NotificationDraft,
+} from '@domains/notifications/notifications.types';
+
+export function buildReleasedNotifications(
+  input: EscrowReleasedInput
+): NotificationDraft[] {
+  const { escrowId, buyerId, sellerId, engagementId, amount } = input;
+  const common = { type: 'escrow_released' as const, escrow_id: escrowId };
+  return [
+    {
+      ...common,
+      user_id: buyerId,
+      title: 'Fondos liberados',
+      body: `Los fondos de tu escrow ${engagementId} fueron liberados al vendedor.`,
+      data: {
+        engagement_id: engagementId,
+        amount,
+        role: 'buyer',
+        counterparty_id: sellerId,
+      },
+    },
+    {
+      ...common,
+      user_id: sellerId,
+      title: 'Recibiste la liberación de fondos',
+      body: `Se liberaron los fondos del escrow ${engagementId}. La operación se completó.`,
+      data: {
+        engagement_id: engagementId,
+        amount,
+        role: 'seller',
+        counterparty_id: buyerId,
+      },
+    },
+  ];
+}
+```
+
+- [ ] **Step 13: Run to verify it passes + commit**
+
+```bash
+cd apps/backend && npm test -- notification-builder escrow-transition notification-prefs
+cd apps/backend && npm run biome:fix && npm run biome:check && cd ../..
+npm run type-check
+git add apps/backend/src/domains/notifications
+git commit -m "feat(backend): add notification pure helpers (transition/prefs/builder) (#139)"
+```
+Expected: PASS (all helper suites).
+
+---
+
+## Task 4: `NotificationsService` + controller + module
+
+**Files:**
+- Create: `apps/backend/src/domains/notifications/notifications.service.ts`, `notifications.service.spec.ts`, `notifications.controller.ts`, `notifications.module.ts`
+
+**Delivery semantics (important):** insert the in-app row FIRST with `email_status='pending'` and `ignoreDuplicates` (UNIQUE backstop). The upsert's `.select('id')` returns the inserted row, or `[]` if it already existed. Only when a NEW row was inserted do we resolve+send the email and then persist the final status — this dedups the email on a crash-retry (re-index re-detects the transition until the escrow status write lands).
+
+- [ ] **Step 1: Write `notifications.service.spec.ts` (failing)**
+
+```ts
+import { NotificationsService } from '@domains/notifications/notifications.service';
+import type { EmailService } from '@core/email/email.service';
+import type { SupabaseService } from '@core/supabase/supabase.service';
+
+// Chainable Supabase mock: notifications upsert(...).select('id') resolves via then();
+// notifications update(...).eq() resolves via then(); users select(...).eq().maybeSingle() resolves the user.
+function makeSupabase(opts: { user?: any; existing?: boolean }) {
+  const inserted: any[] = [];
+  const updates: any[] = [];
+  const client = {
+    from(table: string) {
+      const b: any = {
+        _op: null as null | 'upsert' | 'update',
+        _payload: null as any,
+        upsert(payload: any) {
+          b._op = 'upsert';
+          b._payload = payload;
+          return b;
+        },
+        update(payload: any) {
+          b._op = 'update';
+          b._payload = payload;
+          return b;
+        },
+        select() {
+          return b;
+        },
+        eq() {
+          return b;
+        },
+        maybeSingle() {
+          return Promise.resolve({ data: opts.user ?? null, error: null });
+        },
+        // biome-ignore lint/suspicious/noThenProperty: intentional thenable to mimic Supabase's chainable builder
+        then(resolve: any) {
+          if (table === 'notifications' && b._op === 'upsert') {
+            inserted.push(b._payload);
+            const data = opts.existing ? [] : [{ id: `n-${inserted.length}` }];
+            return Promise.resolve({ data, error: null }).then(resolve);
+          }
+          if (table === 'notifications' && b._op === 'update') {
+            updates.push(b._payload);
+            return Promise.resolve({ data: null, error: null }).then(resolve);
+          }
+          return Promise.resolve({ data: null, error: null }).then(resolve);
+        },
+      };
+      return b;
+    },
+  };
+  return { service: { client } as unknown as SupabaseService, inserted, updates };
+}
+
+const input = {
+  escrowId: 'esc-1',
+  buyerId: 'buyer-1',
+  sellerId: 'seller-1',
+  engagementId: 'eng-1',
+  amount: 250,
+};
+
+describe('NotificationsService.onEscrowReleased', () => {
+  it('inserts a row per party with email skipped when channel disabled', async () => {
+    const { service, inserted, updates } = makeSupabase({ existing: false });
+    const email = { isEnabled: () => false, send: jest.fn() } as unknown as EmailService;
+    await new NotificationsService(service, email).onEscrowReleased(input);
+    expect(inserted).toHaveLength(2);
+    expect(inserted[0].email_status).toBe('pending');
+    // email disabled → resolved to skipped, persisted via update
+    expect(updates.every((u) => u.email_status === 'skipped')).toBe(true);
+    expect((email.send as jest.Mock)).not.toHaveBeenCalled();
+  });
+
+  it('does not resend email for an already-existing row (dedup)', async () => {
+    const { service, updates } = makeSupabase({ existing: true });
+    const email = { isEnabled: () => true, send: jest.fn() } as unknown as EmailService;
+    await new NotificationsService(service, email).onEscrowReleased(input);
+    expect((email.send as jest.Mock)).not.toHaveBeenCalled();
+    expect(updates).toHaveLength(0);
+  });
+
+  it('sends email and marks sent when enabled and pref on', async () => {
+    const { service, updates } = makeSupabase({
+      existing: false,
+      user: { email: 'a@b.com', full_name: 'Alice', notifications: { email_escrows: true } },
+    });
+    const send = jest.fn().mockResolvedValue({ status: 'sent' });
+    const email = { isEnabled: () => true, send } as unknown as EmailService;
+    await new NotificationsService(service, email).onEscrowReleased(input);
+    expect(send).toHaveBeenCalledTimes(2);
+    expect(updates.every((u) => u.email_status === 'sent')).toBe(true);
+  });
+
+  it('skips email when pref email_escrows is off', async () => {
+    const { service, updates } = makeSupabase({
+      existing: false,
+      user: { email: 'a@b.com', notifications: { email_escrows: false } },
+    });
+    const send = jest.fn();
+    const email = { isEnabled: () => true, send } as unknown as EmailService;
+    await new NotificationsService(service, email).onEscrowReleased(input);
+    expect(send).not.toHaveBeenCalled();
+    expect(updates.every((u) => u.email_status === 'skipped')).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd apps/backend && npm test -- notifications.service`
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Implement `notifications.service.ts`**
+
+```ts
+import { renderEscrowReleasedEmail } from '@core/email/templates/escrow-released.template';
+// biome-ignore lint/style/useImportType: required for NestJS dependency injection
+import { EmailService } from '@core/email/email.service';
+// biome-ignore lint/style/useImportType: required for NestJS dependency injection
+import { SupabaseService } from '@core/supabase/supabase.service';
+import { buildReleasedNotifications } from '@domains/notifications/notification-builder';
+import { normalizeNotifications } from '@domains/notifications/notification-prefs';
+import type {
+  EmailStatus,
+  EscrowReleasedInput,
+  NotificationDraft,
+} from '@domains/notifications/notifications.types';
+import { Injectable, Logger } from '@nestjs/common';
+
+@Injectable()
+export class NotificationsService {
+  private readonly logger = new Logger(NotificationsService.name);
+
+  constructor(
+    private readonly supabase: SupabaseService,
+    private readonly email: EmailService
+  ) {}
+
+  async onEscrowReleased(input: EscrowReleasedInput): Promise<void> {
+    for (const draft of buildReleasedNotifications(input)) {
+      try {
+        await this.deliver(draft, input);
+      } catch (err) {
+        this.logger.error(
+          `notify ${draft.user_id} failed: ${(err as Error).message}`
+        );
+      }
+    }
+  }
+
+  private async deliver(
+    draft: NotificationDraft,
+    input: EscrowReleasedInput
+  ): Promise<void> {
+    // Insert first (idempotent). New row → [{id}]; existing → [] (already delivered).
+    const { data: rows, error } = await this.supabase.client
+      .from('notifications')
+      .upsert(
+        { ...draft, email_status: 'pending' as EmailStatus },
+        { onConflict: 'user_id,type,escrow_id', ignoreDuplicates: true }
+      )
+      .select('id');
+    if (error) {
+      this.logger.error(`insert notification failed: ${error.message}`);
+      return;
+    }
+    const row = Array.isArray(rows) ? rows[0] : null;
+    if (!row) {
+      return; // already delivered previously — do not resend
+    }
+
+    const status = await this.resolveEmail(draft, input);
+    await this.supabase.client
+      .from('notifications')
+      .update({ email_status: status })
+      .eq('id', row.id);
+  }
+
+  private async resolveEmail(
+    draft: NotificationDraft,
+    input: EscrowReleasedInput
+  ): Promise<EmailStatus> {
+    if (!this.email.isEnabled()) {
+      return 'skipped';
+    }
+    const { data: user } = await this.supabase.client
+      .from('users')
+      .select('email, full_name, notifications')
+      .eq('id', draft.user_id)
+      .maybeSingle();
+    if (!user?.email) {
+      return 'skipped';
+    }
+    if (!normalizeNotifications(user.notifications).email_escrows) {
+      return 'skipped';
+    }
+    const role = draft.data.role === 'seller' ? 'seller' : 'buyer';
+    const rendered = renderEscrowReleasedEmail({
+      recipientName: user.full_name ?? undefined,
+      role,
+      engagementId: input.engagementId,
+      amount: input.amount,
+    });
+    const { status } = await this.email.send({ to: user.email, ...rendered });
+    return status;
+  }
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd apps/backend && npm test -- notifications.service`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Create `notifications.controller.ts`** (pattern of `escrow.controller.ts`)
+
+```ts
+import { Body, Controller, Get, Param, ParseUUIDPipe, Patch, Query } from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+// biome-ignore lint/style/useImportType: required for NestJS dependency injection
+import { NotificationsService } from '@domains/notifications/notifications.service';
+
+@ApiTags('notifications')
+@Controller()
+export class NotificationsController {
+  constructor(private readonly notifications: NotificationsService) {}
+
+  @Get('notifications/users/:id')
+  @ApiOperation({ summary: 'Recent notifications for a user (most recent first).' })
+  async forUser(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Query('limit') limit?: string
+  ) {
+    const max = Math.min(Math.max(Number(limit) || 50, 1), 200);
+    return { notifications: await this.notifications.listForUser(id, max) };
+  }
+
+  @Get('notifications/users/:id/unread-count')
+  @ApiOperation({ summary: 'Count of unread notifications for a user.' })
+  async unreadCount(@Param('id', ParseUUIDPipe) id: string) {
+    return { count: await this.notifications.unreadCount(id) };
+  }
+
+  @Patch('notifications/:id/read')
+  @ApiOperation({ summary: 'Mark a notification as read.' })
+  async markRead(@Param('id', ParseUUIDPipe) id: string) {
+    return { notification: await this.notifications.markRead(id) };
+  }
+}
+```
+
+- [ ] **Step 6: Add the read/mutate methods to `notifications.service.ts`**
+
+Append these methods inside the `NotificationsService` class (after `onEscrowReleased`):
+```ts
+  async listForUser(userId: string, limit: number): Promise<unknown[]> {
+    const { data, error } = await this.supabase.client
+      .from('notifications')
+      .select('id, type, escrow_id, title, body, data, read_at, email_status, created_at')
+      .eq('user_id', userId)
+      .order('created_at', { ascending: false })
+      .limit(limit);
+    if (error) {
+      throw new Error(`Failed to load notifications for ${userId}: ${error.message}`);
+    }
+    return data ?? [];
+  }
+
+  async unreadCount(userId: string): Promise<number> {
+    const { count, error } = await this.supabase.client
+      .from('notifications')
+      .select('id', { count: 'exact', head: true })
+      .eq('user_id', userId)
+      .is('read_at', null);
+    if (error) {
+      throw new Error(`Failed to count notifications for ${userId}: ${error.message}`);
+    }
+    return count ?? 0;
+  }
+
+  async markRead(id: string): Promise<unknown> {
+    const { data, error } = await this.supabase.client
+      .from('notifications')
+      .update({ read_at: new Date().toISOString() })
+      .eq('id', id)
+      .select('id, read_at')
+      .maybeSingle();
+    if (error) {
+      throw new Error(`Failed to mark notification ${id} read: ${error.message}`);
+    }
+    return data;
+  }
+```
+
+- [ ] **Step 7: Create `notifications.module.ts`**
+
+```ts
+import { NotificationsController } from '@domains/notifications/notifications.controller';
+import { NotificationsService } from '@domains/notifications/notifications.service';
+import { Module } from '@nestjs/common';
+
+@Module({
+  controllers: [NotificationsController],
+  providers: [NotificationsService],
+  exports: [NotificationsService],
+})
+export class NotificationsModule {}
+```
+(`SupabaseService` and `EmailService` come from the `@Global` `SupabaseModule`/`EmailModule`, so no import needed.)
+
+- [ ] **Step 8: Register `NotificationsModule` in `apps/backend/src/app.module.ts`**
+
+Add `import { NotificationsModule } from '@domains/notifications/notifications.module';` and add `NotificationsModule` to the `imports` array (after `EscrowModule`). This mounts the controller routes even before the escrow wiring (Task 5).
+
+- [ ] **Step 9: Biome + type-check + full test + commit**
+
+```bash
+cd apps/backend && npm run biome:fix && npm run biome:check && npm test && cd ../..
+npm run type-check
+git add apps/backend/src/domains/notifications apps/backend/src/app.module.ts
+git commit -m "feat(backend): add notifications service + read API + module (#139)"
+```
+
+---
+
+## Task 5: Wire transition detection into the escrow indexer
+
+**Files:**
+- Modify: `apps/backend/src/domains/escrow/escrow-indexer.service.ts`, `escrow-indexer.service.spec.ts`, `apps/backend/src/domains/escrow/escrow.module.ts`
+
+- [ ] **Step 1: Replace `escrow-indexer.service.spec.ts` with the read-before-write + notify version**
+
+```ts
+import type { SupabaseService } from '@core/supabase/supabase.service';
+import type { TrustlessIndexerService } from '@core/trustless/trustless-indexer.service';
+import type { NotificationsService } from '@domains/notifications/notifications.service';
+import { EscrowIndexerService } from '@domains/escrow/escrow-indexer.service';
+
+// Mock: notifications row read via select().eq().maybeSingle(); escrow update via update().eq().
+function makeSupabase(existing: any | null) {
+  const updates: Array<{ match: string; payload: any }> = [];
+  const client = {
+    from(_table: string) {
+      const b: any = {
+        _payload: null as any,
+        select() {
+          return b;
+        },
+        update(p: any) {
+          b._payload = p;
+          return b;
+        },
+        maybeSingle() {
+          return Promise.resolve({ data: existing, error: null });
+        },
+        eq(_col: string, val: string) {
+          if (b._payload) {
+            updates.push({ match: val, payload: b._payload });
+            return Promise.resolve({ data: null, error: null });
+          }
+          return b;
+        },
+      };
+      return b;
+    },
+  };
+  return { service: { client } as unknown as SupabaseService, updates };
+}
+
+const indexerWith = (escrows: any[]) =>
+  ({
+    isConfigured: () => true,
+    getPlatformEscrows: jest.fn().mockResolvedValue(escrows),
+  }) as unknown as TrustlessIndexerService;
+
+const notifySpy = () => {
+  const onEscrowReleased = jest.fn().mockResolvedValue(undefined);
+  return { svc: { onEscrowReleased } as unknown as NotificationsService, onEscrowReleased };
+};
+
+describe('EscrowIndexerService.indexAll', () => {
+  it('updates the matched escrow row with the mapped patch', async () => {
+    const { service, updates } = makeSupabase({
+      id: 'esc-1',
+      on_chain_status: 'active',
+      buyer_id: 'b',
+      seller_id: 's',
+    });
+    const { svc } = notifySpy();
+    const res = await new EscrowIndexerService(
+      service,
+      indexerWith([{ engagementId: 'eng1', amount: 100, balance: 100, flags: {} }]),
+      svc
+    ).indexAll();
+    expect(res.indexed).toBe(1);
+    expect(updates[0].match).toBe('eng1');
+    expect(updates[0].payload.on_chain_status).toBe('funded');
+  });
+
+  it('notifies once on a funded → released transition, before writing status', async () => {
+    const { service } = makeSupabase({
+      id: 'esc-1',
+      on_chain_status: 'funded',
+      buyer_id: 'b',
+      seller_id: 's',
+    });
+    const { svc, onEscrowReleased } = notifySpy();
+    await new EscrowIndexerService(
+      service,
+      indexerWith([{ engagementId: 'eng1', amount: 100, balance: 100, flags: { released: true } }]),
+      svc
+    ).indexAll();
+    expect(onEscrowReleased).toHaveBeenCalledTimes(1);
+    expect(onEscrowReleased).toHaveBeenCalledWith({
+      escrowId: 'esc-1',
+      buyerId: 'b',
+      sellerId: 's',
+      engagementId: 'eng1',
+      amount: 100,
+    });
+  });
+
+  it('does NOT notify when already released (idempotent) or on baseline (no prior row)', async () => {
+    const already = makeSupabase({ id: 'esc-1', on_chain_status: 'released', buyer_id: 'b', seller_id: 's' });
+    const n1 = notifySpy();
+    await new EscrowIndexerService(
+      already.service,
+      indexerWith([{ engagementId: 'eng1', amount: 1, balance: 1, flags: { released: true } }]),
+      n1.svc
+    ).indexAll();
+    expect(n1.onEscrowReleased).not.toHaveBeenCalled();
+
+    const missing = makeSupabase(null);
+    const n2 = notifySpy();
+    const res = await new EscrowIndexerService(
+      missing.service,
+      indexerWith([{ engagementId: 'eng1', amount: 1, balance: 1, flags: { released: true } }]),
+      n2.svc
+    ).indexAll();
+    expect(n2.onEscrowReleased).not.toHaveBeenCalled();
+    expect(res.unmatched).toBe(1);
+  });
+
+  it('no-ops when TLW is not configured', async () => {
+    const { service } = makeSupabase(null);
+    const { svc } = notifySpy();
+    const notConfigured = {
+      isConfigured: () => false,
+      getPlatformEscrows: jest.fn(),
+    } as unknown as TrustlessIndexerService;
+    const res = await new EscrowIndexerService(service, notConfigured, svc).indexAll();
+    expect(res.indexed).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd apps/backend && npm test -- escrow-indexer`
+Expected: FAIL (constructor arity / `maybeSingle` not handled by old code).
+
+- [ ] **Step 3: Rewrite `escrow-indexer.service.ts`**
+
+```ts
+import { Injectable, Logger } from '@nestjs/common';
+// biome-ignore lint/style/useImportType: required for NestJS dependency injection
+import { SupabaseService } from '@core/supabase/supabase.service';
+// biome-ignore lint/style/useImportType: required for NestJS dependency injection
+import { TrustlessIndexerService } from '@core/trustless/trustless-indexer.service';
+import { toEscrowPatch } from '@domains/escrow/escrow-mapper';
+// biome-ignore lint/style/useImportType: required for NestJS dependency injection
+import { NotificationsService } from '@domains/notifications/notifications.service';
+import { detectEscrowTransition } from '@domains/notifications/escrow-transition';
+
+@Injectable()
+export class EscrowIndexerService {
+  private readonly logger = new Logger(EscrowIndexerService.name);
+
+  constructor(
+    private readonly supabase: SupabaseService,
+    private readonly indexer: TrustlessIndexerService,
+    private readonly notifications: NotificationsService
+  ) {}
+
+  async indexAll(): Promise<{ indexed: number; unmatched: number }> {
+    if (!this.indexer.isConfigured()) {
+      this.logger.warn(
+        'TLW not configured (TLW_API_KEY/PLATFORM_ROLE_ADDRESS); skipping escrow indexing'
+      );
+      return { indexed: 0, unmatched: 0 };
+    }
+    const escrows = await this.indexer.getPlatformEscrows();
+    const now = Date.now();
+    let indexed = 0;
+    let unmatched = 0;
+    for (const escrow of escrows) {
+      if (!escrow.engagementId) {
+        continue;
+      }
+      const patch = toEscrowPatch(escrow, now);
+
+      // Read prior state to detect a transition (and to resolve the parties).
+      const { data: existing } = await this.supabase.client
+        .from('escrows')
+        .select('id, on_chain_status, buyer_id, seller_id')
+        .eq('engagement_id', escrow.engagementId)
+        .maybeSingle();
+      if (!existing) {
+        unmatched += 1;
+        continue; // web owns row creation; we only enrich existing rows
+      }
+
+      // Crash-safe: notify BEFORE writing the new status (re-index re-detects
+      // until the status write lands; NotificationsService dedups via UNIQUE).
+      const transition = detectEscrowTransition(
+        existing.on_chain_status,
+        patch.on_chain_status
+      );
+      if (transition?.kind === 'escrow_released') {
+        await this.notifications.onEscrowReleased({
+          escrowId: existing.id,
+          buyerId: existing.buyer_id,
+          sellerId: existing.seller_id,
+          engagementId: escrow.engagementId,
+          amount: patch.token_amount,
+        });
+      }
+
+      const { error } = await this.supabase.client
+        .from('escrows')
+        .update({ ...patch, updated_at: new Date(now).toISOString() })
+        .eq('engagement_id', escrow.engagementId);
+      if (error) {
+        this.logger.error(
+          `index ${escrow.engagementId} failed: ${error.message}`
+        );
+        unmatched += 1;
+      } else {
+        indexed += 1;
+      }
+    }
+    this.logger.log(
+      `escrow index done indexed=${indexed} unmatched=${unmatched}`
+    );
+    return { indexed, unmatched };
+  }
+}
+```
+Note on the test mock: the recording builder resolves `.eq(...)` to a promise only when an update payload was set; otherwise `.eq(...)` returns the builder and `.maybeSingle()` resolves the prior row. This mirrors the two call shapes (`select().eq().maybeSingle()` and `update().eq()`).
+
+- [ ] **Step 4: Import `NotificationsModule` in `apps/backend/src/domains/escrow/escrow.module.ts`**
+
+```ts
+import { EscrowController } from '@domains/escrow/escrow.controller';
+import { EscrowService } from '@domains/escrow/escrow.service';
+import { EscrowIndexCron } from '@domains/escrow/escrow-index.cron';
+import { EscrowIndexerService } from '@domains/escrow/escrow-indexer.service';
+import { NotificationsModule } from '@domains/notifications/notifications.module';
+import { Module } from '@nestjs/common';
+
+@Module({
+  imports: [NotificationsModule],
+  controllers: [EscrowController],
+  providers: [EscrowService, EscrowIndexerService, EscrowIndexCron],
+})
+export class EscrowModule {}
+```
+(`NotificationsModule` exports `NotificationsService`, so `EscrowIndexerService` can inject it.)
+
+- [ ] **Step 5: Run tests**
+
+Run: `cd apps/backend && npm test -- escrow-indexer`
+Expected: PASS (4 tests).
+
+- [ ] **Step 6: Build + DI smoke**
+
+```bash
+rm -rf apps/backend/dist apps/backend/*.tsbuildinfo && (cd apps/backend && npm run build)
+grep -n "design:paramtypes" apps/backend/dist/domains/escrow/escrow-indexer.service.js apps/backend/dist/domains/notifications/notifications.service.js
+# → must reference real classes (SupabaseService/TrustlessIndexerService/NotificationsService; SupabaseService/EmailService), NOT [void 0]
+rm -rf apps/backend/dist apps/backend/*.tsbuildinfo
+```
+Expected: `design:paramtypes` lists the injected classes (DI intact).
+
+- [ ] **Step 7: Biome + type-check + commit**
+
+```bash
+cd apps/backend && npm run biome:fix && npm run biome:check && cd ../..
+npm run type-check
+git add apps/backend/src/domains/escrow
+git commit -m "feat(backend): emit escrow-released notification from indexer (#139)"
+```
+
+---
+
+## Task 6: Final verification + PR
+
+- [ ] **Step 1: Full verification**
+
+```bash
+cd apps/backend && npm test && npm run biome:check && cd ../..
+rm -rf apps/backend/dist apps/backend/*.tsbuildinfo
+npm run type-check
+npm run build
+```
+Expected: Jest green (template, email, transition, prefs, builder, notifications.service, escrow-indexer + prior suites); type-check + root build pass; backend biome clean.
+
+- [ ] **Step 2: Apply the migration to dev + boot acceptance**
+
+Apply `20260627120000_create_notifications.sql` to the dev project (`kzlsbhpyszkalyflbqjg`) via the Supabase MCP `apply_migration` (additive/idempotent). Then:
+```bash
+rm -rf apps/backend/dist apps/backend/*.tsbuildinfo && (cd apps/backend && npm run build)
+( cd apps/backend && node dist/main.js & sleep 2 ; KEY=$(grep '^INTERNAL_API_KEY=' .env | cut -d= -f2) ; \
+  echo -n "no key -> " ; curl -s -o /dev/null -w "%{http_code}\n" localhost:3001/v1/notifications/users/00000000-0000-0000-0000-000000000000 ; \
+  echo -n "list -> " ; curl -s -w " [%{http_code}]\n" -H "x-internal-key: $KEY" localhost:3001/v1/notifications/users/00000000-0000-0000-0000-000000000000 ; \
+  echo -n "unread -> " ; curl -s -w " [%{http_code}]\n" -H "x-internal-key: $KEY" localhost:3001/v1/notifications/users/00000000-0000-0000-0000-000000000000/unread-count ; \
+  kill %1 ) 2>&1 | grep -iE "no key|list|unread"
+rm -rf apps/backend/dist apps/backend/*.tsbuildinfo
+```
+Expected: `no key -> 401`; `list -> {"notifications":[]} [200]`; `unread -> {"count":0} [200]`.
+
+- [ ] **Step 3: (Optional) live transition check**
+
+With `RESEND_API_KEY` empty and the escrow indexer running against a real TLW escrow that moves to `released`: two `notifications` rows appear (buyer + seller) with `email_status='skipped'`; a second indexer tick does not duplicate (UNIQUE). With `RESEND_API_KEY` set (free tier) and the recipient's `email_escrows=true`, the row's `email_status='sent'` and a real email arrives.
+
+- [ ] **Step 4: Push + open PR**
+
+```bash
+git push -u origin feat/139-notifications
+gh pr create --repo PACTO-LAT/pacto-p2p --base develop --head feat/139-notifications \
+  --title "feat(backend): notification service (phase 5 — #139)" \
+  --body "<summary: in-app notifications persisted on escrow→released (both parties); email channel via Resend implemented but DISABLED by empty RESEND_API_KEY; read API GET /v1/notifications/users/:id (+unread-count, PATCH read); read-before-write transition detection added to the escrow indexer (crash-safe + idempotent via UNIQUE); migration applied to dev. Stacked on #138a. No on-chain writes.>"
+```
+(No `Co-Authored-By`, no "Generated with Claude" footer. Branch is stacked on `feat/138a-escrow-indexing`; the diff includes #138a commits until it merges.)
+
+---
+
+## Self-review checklist (completed during planning)
+
+- **Spec coverage:** migration + email env + `resend` dep (T1); `core/email` disabled-by-default + template (T2); pure `detectEscrowTransition`/`normalizeNotifications`/`buildReleasedNotifications` (T3); `NotificationsService` insert+conditional-email + read API (T4); read-before-write transition wiring in the indexer (T5); verify + dev migration + PR (T6). Every spec section maps to a task.
+- **Type consistency:** `NotificationDraft`, `EscrowReleasedInput`, `EmailStatus`, `TransitionEvent`, `NotificationPrefs` are defined once in `notifications.types.ts` (T3 Step 1) and consumed unchanged by the builder (T3), service (T4), transition (T3), and indexer (T5). `renderEscrowReleasedEmail`'s `EscrowReleasedEmailData`/`RenderedEmail` live in the template (T2) and are used by the service (T4). The service's `onEscrowReleased(input)` signature matches the indexer's call site (T5) exactly (`escrowId/buyerId/sellerId/engagementId/amount`).
+- **No placeholders:** every code step is complete. The only narrative integration point is the dev migration application in T6 (Supabase MCP), which is an action, not code.
+- **Delivery correctness:** insert-first-then-email dedups the email on crash-retry (re-index re-detects the transition until the status write lands; UNIQUE makes the re-insert a no-op and the empty `.select('id')` short-circuits the resend). In-app row is always created; email gated by `email_escrows` AND `isEnabled()`.
+- **DI footgun:** `EmailService`, `SupabaseService`, `NotificationsService`, `TrustlessIndexerService` are VALUE imports with the biome-ignore; verified via the `design:paramtypes` grep in T5 Step 6.
+- **Out of scope (per spec):** web UI, push/SMS, events other than `released`, email retry worker, stats-driven notifications, phase 4b sweep.
+```

--- a/docs/superpowers/specs/2026-06-27-backend-notifications-phase5-design.md
+++ b/docs/superpowers/specs/2026-06-27-backend-notifications-phase5-design.md
@@ -1,0 +1,206 @@
+# Backend Phase 5 — Notification Service (Issue #139)
+
+**Status:** Design approved (pending spec review)
+**Date:** 2026-06-27
+**Issue:** [#139 — feat(backend): notification service (phase 5)](https://github.com/PACTO-LAT/pacto-p2p/issues/139)
+**Depends on:** #135 (scaffold), #136 (stats, merged), #137 (cron — stacked), #138a (escrow indexing — this branch is on `feat/138a-escrow-indexing`, provides the escrow state the events derive from).
+
+## Context
+
+The backend (`apps/backend`) now indexes on-chain escrow state (#138a) but **notifies users of
+nothing** when an escrow changes state. Notification *types* and per-user preference toggles already
+exist in the web (`apps/web/lib/types.ts`, `components/profile/NotificationSettings.tsx`,
+`users.notifications` JSONB column) but there is **no sender and no persistence** — the only emails
+sent today are waitlist OTPs from `apps/web`.
+
+This phase adds a backend **notification service**: when the escrow indexer detects a state
+transition, it **persists in-app notification rows** and (optionally) sends an email. v1 fires on
+**escrow released** only.
+
+### Findings from exploration (shape the design)
+- **`users.notifications` JSONB** shape (canonical): `{ email_trades, email_escrows,
+  push_notifications, sms_notifications }`; defaults `email_*`/`push` = true, `sms` = false. Loose
+  legacy variants exist in seed data (`{ email, push }`) — the web normalizes via
+  `apps/web/lib/utils/normalize-user.ts` `normalizeNotifications()`. There is **no `notifications`
+  table** yet (only the prefs column).
+- **`escrows` table already has `buyer_id` and `seller_id`** (both UUID FK → `users`), so mapping an
+  escrow to the users to notify is direct — no wallet-address resolution. `users.email` and
+  `users.full_name` provide the email recipient and display name.
+- **Resend** is used only in `apps/web` (`resend@^4.8.0`, env `RESEND_API_KEY`, sender
+  `Pacto <no-reply@pacto.app>`). The backend has **no Resend dependency yet**; the phase-1 scaffold
+  spec already earmarked `core/email` (Resend) for #139. Resend's free tier is 100 emails/day /
+  3,000/month — no cost at current (pre-launch) volume.
+- **`docs/email-templates/`** contains only a README for Supabase **Auth** templates — no
+  transactional templates. Our transactional emails live as typed TS render functions, not files.
+- **The escrow indexer does a blind upsert** (`escrow-indexer.service.ts` lines 28–45): it overwrites
+  each row with the latest `toEscrowPatch(...)` and **does not compare old vs new**. There is **no
+  EventEmitter/queue** in the backend (`@nestjs/event-emitter` is not a dependency). Transition
+  detection must be **added**.
+- **`on_chain_status`** is derived by `escrow-mapper.ts` from flags/balance:
+  `resolved` → `released` → `disputed` → (`balance>0`) `funded` → else `active`.
+
+## Decisions (approved)
+
+1. **In-app first, email off by flag.** Persist notifications to a new `notifications` table ($0,
+   no external service). The **email channel is implemented but disabled** by feature flag
+   (`RESEND_API_KEY` empty default — the repo's standard for optional integrations). Enabling email
+   later is just setting the key — no rework.
+2. **v1 event = escrow `→released` only**, notifying **both parties** (buyer + seller). The system is
+   event-driven and extensible — adding `funded`/`disputed`/`resolved` is a mapping addition.
+3. **Backend-only.** Table + write-on-transition + read API. Web UI (bell/feed) is a separate
+   frontend issue; the web will consume the read API server-side (`backendFetch` + `requireUser`).
+4. **`resend` npm package** (parity with web) for the email channel; **inline send** (await after
+   creating the row) — **no retry cron** for now (`email_status='failed'` rows are the seam for a
+   future retry job).
+
+## Architecture
+
+```
+apps/backend/src/
+├── core/email/
+│   ├── email.module.ts          # @Global, exports EmailService
+│   ├── email.config.ts          # reads RESEND_API_KEY, EMAIL_FROM
+│   ├── email.service.ts         # isEnabled() + send(); no-op (skipped) when disabled
+│   ├── email.service.spec.ts
+│   └── templates/
+│       ├── escrow-released.template.ts   # renderEscrowReleasedEmail(data) → {subject, html, text}
+│       └── escrow-released.template.spec.ts
+└── domains/notifications/
+    ├── notifications.module.ts   # imported by EscrowModule; imports nothing escrow-side (one-way)
+    ├── notifications.service.ts  # onEscrowReleased(...) → insert rows + (maybe) email
+    ├── notifications.service.spec.ts
+    ├── notifications.controller.ts   # GET/PATCH /v1/notifications... (InternalApiKeyGuard)
+    ├── notification-prefs.ts     # PURE: normalizeNotifications(jsonb) (ported from web)
+    ├── notification-prefs.spec.ts
+    ├── notification-builder.ts   # PURE: buildReleasedNotifications(escrowRow) → NotificationDraft[]
+    ├── notification-builder.spec.ts
+    ├── escrow-transition.ts      # PURE: detectEscrowTransition(old, new) → TransitionEvent | null
+    ├── escrow-transition.spec.ts
+    └── notifications.types.ts
+```
+`EscrowModule` imports `NotificationsModule` (one-way Escrow → Notifications; clean boundaries —
+Notifications does not depend on Escrow). `EmailModule` is registered `@Global` in `CoreModule`
+(infrastructure). `app.module.ts` already imports `EscrowModule`.
+
+## Components
+
+### `core/email` (infra, disabled by default)
+- **`email.config.ts`**: reads `RESEND_API_KEY` (empty → disabled) and `EMAIL_FROM`
+  (default `Pacto <no-reply@pacto.app>`).
+- **`email.service.ts`**: `isEnabled(): boolean` (key present). `send({ to, subject, html, text }):
+  Promise<{ status: 'sent' | 'failed' | 'skipped' }>` — if disabled returns `{ skipped }` **without
+  constructing the Resend client or making any network call**; if enabled, sends via the `resend`
+  package and maps success/error. Never throws to the caller (logs on failure, returns `failed`).
+- **`templates/escrow-released.template.ts`** (pure): `renderEscrowReleasedEmail(data)` →
+  `{ subject, html, text }`, role-aware copy (buyer vs seller). Unit-tested.
+
+### `domains/notifications`
+- **`escrow-transition.ts`** (pure): `detectEscrowTransition(oldStatus: string | null, newStatus:
+  string): TransitionEvent | null`. Returns `{ kind: 'escrow_released' }` only when
+  `oldStatus != null && oldStatus !== 'released' && newStatus === 'released'`. **Anti-backfill
+  guard:** `oldStatus == null` (never indexed) → returns `null` (baseline). Extensible: future
+  transitions add cases here. Unit-tested across the status matrix.
+- **`notification-prefs.ts`** (pure): `normalizeNotifications(value: unknown): NotificationPrefs`,
+  ported from `apps/web/lib/utils/normalize-user.ts` (handles canonical + legacy `{email,push}` +
+  defaults). Unit-tested.
+- **`notification-builder.ts`** (pure): `buildReleasedNotifications(escrow): NotificationDraft[]` —
+  returns two drafts (buyer + seller) with `type:'escrow_released'`, role-aware `title`/`body`, and
+  `data` (`engagement_id`, amount, counterparty, role). Unit-tested.
+- **`notifications.service.ts`**: `onEscrowReleased(input: { escrowId, buyerId, sellerId,
+  engagementId, amount, ... })`:
+  1. `buildReleasedNotifications(...)` → 2 drafts.
+  2. For each draft: **insert the in-app row** (`insert ... onConflict (user_id,type,escrow_id) do
+     nothing`). The in-app row is **always** created (not gated by email prefs).
+  3. Determine email: load the recipient's `users.notifications` + `email`, run
+     `normalizeNotifications`; email is sent only if `email_escrows === true` **and**
+     `EmailService.isEnabled()`. Render template, `EmailService.send(...)`, set `email_status` ←
+     `sent` | `failed` | `skipped` (skipped when pref off or channel disabled).
+  - Never throws into the indexer (logs and continues) — a notification failure must not break
+    indexing.
+- **`notifications.controller.ts`** (behind global `InternalApiKeyGuard`, pattern of
+  `escrow.controller.ts`):
+  - `GET /v1/notifications/users/:id` (`ParseUUIDPipe`, optional `limit`) → `{ notifications: [...] }`
+    most-recent-first.
+  - `GET /v1/notifications/users/:id/unread-count` → `{ count }`.
+  - `PATCH /v1/notifications/:id/read` → sets `read_at`, returns the updated row.
+
+### Escrow indexer change (`domains/escrow/escrow-indexer.service.ts`)
+Change the blind upsert to **read-before-write**:
+1. Before updating, read the existing row's `id, on_chain_status, buyer_id, seller_id` (matched by
+   `engagement_id`).
+2. Compute `patch = toEscrowPatch(...)`. Run `detectEscrowTransition(old.on_chain_status,
+   patch.on_chain_status)`.
+3. **Crash-safe order:** if a transition is detected, first
+   `await notifications.onEscrowReleased({ escrowId: old.id, buyerId, sellerId, engagementId, amount
+   })` (idempotent via the UNIQUE constraint), **then** update the escrow row's status/state.
+4. If the row doesn't exist (unmatched) keep current behavior (skip; the web owns creation).
+
+`EscrowIndexerService` gains a `NotificationsService` constructor dep (VALUE import + biome-ignore).
+`EscrowModule` imports `NotificationsModule`.
+
+### Migration
+`supabase/migrations/<ts>_create_notifications.sql`:
+```sql
+CREATE TABLE IF NOT EXISTS notifications (
+  id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id      UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  type         TEXT NOT NULL,
+  escrow_id    UUID REFERENCES escrows(id) ON DELETE CASCADE,
+  title        TEXT NOT NULL,
+  body         TEXT NOT NULL,
+  data         JSONB NOT NULL DEFAULT '{}'::jsonb,
+  read_at      TIMESTAMPTZ,
+  email_status TEXT NOT NULL DEFAULT 'skipped',
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE UNIQUE INDEX IF NOT EXISTS uq_notifications_user_type_escrow
+  ON notifications(user_id, type, escrow_id);
+CREATE INDEX IF NOT EXISTS idx_notifications_user_created
+  ON notifications(user_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_notifications_email_pending
+  ON notifications(email_status) WHERE email_status = 'pending';
+```
+Applied to the dev project (`kzlsbhpyszkalyflbqjg`) via the Supabase MCP `apply_migration`
+(additive/idempotent) **before** the backend writes the table. RLS: enable + a select-own policy
+consistent with the other tables (backend uses the service-role client, which bypasses RLS).
+
+### Env (backend)
+`RESEND_API_KEY` (string, `allow('')`, default `''` → email disabled) and `EMAIL_FROM`
+(string, default `Pacto <no-reply@pacto.app>`). Joi in `config/env.validation.ts` +
+`apps/backend/.env.example`. Empty default so missing config doesn't fail boot (feature-flag style).
+
+## Testing
+- **Pure unit:** `escrow-transition.spec.ts` (full old→new status matrix incl. null baseline),
+  `notification-prefs.spec.ts` (canonical/legacy/defaults), `notification-builder.spec.ts`
+  (two drafts, role-aware copy, `data` payload), `escrow-released.template.spec.ts`
+  (subject/html/text, buyer vs seller).
+- **`email.service.spec.ts`:** disabled path returns `{ skipped }` and makes **no** network call;
+  enabled path (Resend mocked) maps success → `sent`, error → `failed` (no throw).
+- **`notifications.service.spec.ts`** (hand-rolled chainable Supabase mock): inserts both rows;
+  in-app row always created; `email_status` = `skipped` when pref off or channel disabled, `sent`
+  when both on; `onConflict` dedup on re-run.
+- **`escrow-indexer.service.spec.ts`** (extend): detects `funded→released`, calls
+  `onEscrowReleased` once, then updates the row; `released→released` and `null→released` (baseline)
+  do **not** notify.
+
+## Verification (end-to-end)
+1. Apply the migration to the dev project; confirm `notifications` exists.
+2. `cd apps/backend && rm -rf dist *.tsbuildinfo && npm run build` compiles clean; compiled `dist`
+   `design:paramtypes` for the changed services is not `[void 0]` (DI intact). `npm test` green
+   (new + existing). Backend `biome:check` clean.
+3. `GET /v1/notifications/users/<uuid>` (with `x-internal-key`) → `200 { "notifications": [] }` for a
+   user with none; `…/unread-count` → `{ "count": 0 }`.
+4. Simulate a transition (indexer with `CRON_ENABLED=true`, or a direct `indexAll()` call) where an
+   escrow goes `funded → released`: two `notifications` rows appear (buyer + seller),
+   `email_status='skipped'` (key empty); a second tick does **not** duplicate (UNIQUE).
+5. With `RESEND_API_KEY` set (free tier) and a recipient whose `email_escrows=true`, a transition
+   sends a real email and that row's `email_status='sent'`.
+6. `PATCH /v1/notifications/<id>/read` sets `read_at`; `unread-count` decreases.
+
+## Out of scope (#139)
+- **Web UI** (notification bell/feed) — separate frontend issue; this phase only exposes the read API.
+- **Push / SMS channels** — the UI toggles exist but stay inert (YAGNI).
+- **Events other than `released`** — `funded`/`disputed`/`resolved` are trivial extensions later.
+- **Email retry/queue worker** — inline send only; `email_status='failed'` is the future seam.
+- **Stats-driven notifications** (reputation/threshold) — not in v1.
+- **Phase 4b stuck-escrow sweep** (remaining half of #138) — separate work.

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "nestjs-pino": "^4.1.0",
         "pino-http": "^10.0.0",
         "reflect-metadata": "^0.2.2",
+        "resend": "^4.8.0",
         "rxjs": "^7.8.1"
       },
       "devDependencies": {

--- a/supabase/migrations/20260627120000_create_notifications.sql
+++ b/supabase/migrations/20260627120000_create_notifications.sql
@@ -1,0 +1,25 @@
+-- Persist in-app notifications. email_status tracks the optional email channel.
+CREATE TABLE IF NOT EXISTS notifications (
+  id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id      UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  type         TEXT NOT NULL,
+  escrow_id    UUID REFERENCES escrows(id) ON DELETE CASCADE,
+  title        TEXT NOT NULL,
+  body         TEXT NOT NULL,
+  data         JSONB NOT NULL DEFAULT '{}'::jsonb,
+  read_at      TIMESTAMPTZ,
+  email_status TEXT NOT NULL DEFAULT 'skipped',
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_notifications_user_type_escrow
+  ON notifications(user_id, type, escrow_id);
+CREATE INDEX IF NOT EXISTS idx_notifications_user_created
+  ON notifications(user_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_notifications_email_pending
+  ON notifications(email_status) WHERE email_status = 'pending';
+
+ALTER TABLE notifications ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS notifications_select_own ON notifications;
+CREATE POLICY notifications_select_own ON notifications FOR SELECT
+  USING (auth.uid() = user_id);


### PR DESCRIPTION
## Summary

Backend notification service (phase 5 / #139). When the escrow indexer detects an escrow transition to **`released`**, it persists **two in-app notifications** (buyer + seller) into a new `notifications` table, and optionally sends an email via Resend.

- **Email off by default**: the Resend channel is implemented but disabled while `RESEND_API_KEY` is empty (no client constructed, no network call). In-app notifications work at $0 cost.
- **v1 event**: only `->released` (to both parties). The system is event-driven and extensible (adding `funded`/`disputed`/`resolved` = a mapping addition).
- **Read API** (behind the global `InternalApiKeyGuard`): `GET /v1/notifications/users/:id`, `GET /v1/notifications/users/:id/unread-count`, `PATCH /v1/notifications/:id/read`.

closes #139

## Technical details

- **Transition detection**: the escrow indexer moved from a *blind upsert* to **read-before-write** — it reads the prior `on_chain_status`, runs `detectEscrowTransition(old, new)`, and notifies **before** writing the new status (crash-safe). Anti-backfill guard: a `null` prior `on_chain_status` (never indexed) does not fire.
- **Idempotency**: `UNIQUE(user_id, type, escrow_id)` + upsert `ignoreDuplicates`. The in-app row is inserted first (`email_status='pending'`) and the email is only sent/persisted when the row is new -> no duplicate emails on retries.
- **`core/email`**: `EmailService` (`@Global`) with `isEnabled()`/`send()`; typed template `renderEscrowReleasedEmail`. Email gated by the user's `email_escrows` pref **and** `isEnabled()`.
- Migration `20260627120000_create_notifications.sql` (applied to the dev project).

## Notes

- **Stacked** on `feat/138a-escrow-indexing` (PR #152, not yet merged) — the diff includes #138a commits until that PR lands.
- The backend **does not sign on-chain** (read-only); out of scope: web UI, push/SMS, email retry worker, phase 4b (stuck-escrow sweep).

## Test plan

- [x] Backend: 47 tests green (pure helpers, EmailService disabled-path, NotificationsService delivery/dedup, indexer transition matrix).
- [x] `type-check` 9/9 and root `build` OK; DI verified (real `design:paramtypes`, not `[void 0]`).
- [x] Migration applied to dev; boot + smoke: `GET .../users/:id` -> `200 {"notifications":[]}`, `unread-count` -> `200 {"count":0}`, without `x-internal-key` -> `401`, invalid uuid -> `400`.
- [ ] (Optional, once email is enabled) with `RESEND_API_KEY` set and `email_escrows=true`, a `->released` transition sends a real email and the row becomes `email_status='sent'`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added in-app notifications for escrow releases, including separate messages for buyers and sellers.
  * Added notification inbox actions: view recent notifications, check unread count, and mark notifications as read.
  * Added optional email alerts for escrow releases when email notifications are enabled.

* **Bug Fixes**
  * Improved duplicate prevention so escrow release notifications are only created once per transaction.
  * Notification emails are now skipped cleanly when email is disabled or a user has opted out.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
