### PR TITLE
chore(web): fix safe Biome lint violations in admin routes & UI a11y (#155)

### DIFF
--- a/apps/web/app/api/admin/audit-logs/route.ts
+++ b/apps/web/app/api/admin/audit-logs/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 import { AuditService } from '@/lib/services/audit';
+import type { AuditAction, AuditTargetType } from '@/lib/types/audit';
 import { requireAdmin } from '@/lib/utils/require-admin';
 
 export async function GET(request: NextRequest) {
@@ -18,15 +19,15 @@ export async function GET(request: NextRequest) {
     const [logs, total] = await Promise.all([
       AuditService.getAuditLogs({
         adminUserId,
-        action: action as any,
-        targetType: targetType as any,
+        action: action as AuditAction | undefined,
+        targetType: targetType as AuditTargetType | undefined,
         limit,
         offset,
       }),
       AuditService.getAuditLogsCount({
         adminUserId,
-        action: action as any,
-        targetType: targetType as any,
+        action: action as AuditAction | undefined,
+        targetType: targetType as AuditTargetType | undefined,
       }),
     ]);
 

--- a/apps/web/app/api/admin/merchants/[id]/route.ts
+++ b/apps/web/app/api/admin/merchants/[id]/route.ts
@@ -21,7 +21,7 @@ export async function PATCH(
       reason,
     };
 
-    let data;
+    let data: unknown;
     if (action === 'approve') {
       data = await AdminService.approveMerchant(id, auditContext);
     } else if (action === 'reject') {

--- a/apps/web/components/admin/audit-log-viewer.tsx
+++ b/apps/web/components/admin/audit-log-viewer.tsx
@@ -136,6 +136,7 @@ export function AuditLogViewer({ className }: AuditLogViewerProps) {
               </div>
               <div className="flex gap-2">
                 <button
+                  type="button"
                   onClick={() => handlePageChange(Math.max(0, filters.offset - filters.limit))}
                   disabled={filters.offset === 0}
                   className="px-3 py-1 border rounded disabled:opacity-50"
@@ -143,6 +144,7 @@ export function AuditLogViewer({ className }: AuditLogViewerProps) {
                   Previous
                 </button>
                 <button
+                  type="button"
                   onClick={() => handlePageChange(filters.offset + filters.limit)}
                   disabled={filters.offset + filters.limit >= data.total}
                   className="px-3 py-1 border rounded disabled:opacity-50"

--- a/apps/web/components/ui/logo-loop.tsx
+++ b/apps/web/components/ui/logo-loop.tsx
@@ -359,7 +359,6 @@ export const LogoLoop = React.memo<LogoLoopProps>(
                 scaleOnHover && 'overflow-visible group/item'
               )}
               key={key}
-              role="listitem"
             >
               {renderItem(item, key)}
             </li>
@@ -436,7 +435,6 @@ export const LogoLoop = React.memo<LogoLoopProps>(
               scaleOnHover && 'overflow-visible group/item'
             )}
             key={key}
-            role="listitem"
           >
             {inner}
           </li>

--- a/apps/web/components/ui/macbook-scroll.tsx
+++ b/apps/web/components/ui/macbook-scroll.tsx
@@ -619,6 +619,7 @@ export const OptionKey = ({ className }: { className: string }) => {
       viewBox="0 0 32 32"
       className={className}
     >
+      <title>Option key</title>
       <rect
         stroke="currentColor"
         strokeWidth={2}


### PR DESCRIPTION
> Closed — superseded by #157, which includes these same safe fixes plus the global formatting of apps/web.

Addresses the **safe subset** of #155 (no regression risk). Intentionally does NOT make `biome check` 100% green — see "Scope" below.

## Changes (5 files, +9 / -7)

- `app/api/admin/audit-logs/route.ts` — replaces 4x `as any` with typed casts (`AuditAction | undefined` / `AuditTargetType | undefined`) + the type import.
- `app/api/admin/merchants/[id]/route.ts` — `let data;` -> `let data: unknown;` (resolves `noImplicitAnyLet`).
- `components/admin/audit-log-viewer.tsx` — `type="button"` on the 2 pagination buttons (`useButtonType`).
- `components/ui/logo-loop.tsx` — removes 2x redundant `role="listitem"` on `<li>` (`noRedundantRoles`).
- `components/ui/macbook-scroll.tsx` — `<title>` on the decorative svg (`noSvgWithoutTitle`).

## Scope (important)

While running the cleanup it turned out the real picture is **much larger** than the truncated output showed when #155 was opened:

- `biome check .` reports **~43 errors + ~48 warnings** (not ~6).
- Also, **the repo is not globally Biome-formatted**: `biome check --write .` reformats **~99 files** (formatting only). That is massive, conflict-prone churn, outside a focused PR.
- Most of the 43 errors are **behavioral/judgment** rules (`useHookAtTopLevel`, `useExhaustiveDependencies`, `noArrayIndexKey`, a11y `useSemanticElements`/`noStaticElementInteractions`, `noImgElement`, etc.) — fixing them blindly can introduce regressions.

So this PR lands **only the mechanically-safe** changes in their own files (without touching repo formatting). `biome check` stays red; going green repo-wide is a separate decision (global format commit + behavioral-rule fixes with review/testing). #155 updated with this real scope.

## Test plan

- [x] `npm run type-check` -> 9/9.
- [x] `npm run build` -> OK.
- [x] Target rules resolved in the 5 files (verified with `biome check`); no new violations introduced.
- [x] No repo-wide reformatting (diff scoped to 5 files).
