### PR TITLE
chore: format with Biome + fix safe lint violations (#155)

### DIFF
--- a/apps/web/app/api/admin/audit-logs/route.ts
+++ b/apps/web/app/api/admin/audit-logs/route.ts
@@ -1,6 +1,7 @@
-import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
 import { AuditService } from '@/lib/services/audit';
+import type { AuditAction, AuditTargetType } from '@/lib/types/audit';
 import { requireAdmin } from '@/lib/utils/require-admin';
 
 export async function GET(request: NextRequest) {
@@ -18,15 +19,15 @@ export async function GET(request: NextRequest) {
     const [logs, total] = await Promise.all([
       AuditService.getAuditLogs({
         adminUserId,
-        action: action as any,
-        targetType: targetType as any,
+        action: action as AuditAction | undefined,
+        targetType: targetType as AuditTargetType | undefined,
         limit,
         offset,
       }),
       AuditService.getAuditLogsCount({
         adminUserId,
-        action: action as any,
-        targetType: targetType as any,
+        action: action as AuditAction | undefined,
+        targetType: targetType as AuditTargetType | undefined,
       }),
     ]);
 

--- a/apps/web/app/api/admin/merchants/[id]/route.ts
+++ b/apps/web/app/api/admin/merchants/[id]/route.ts
@@ -1,5 +1,5 @@
-import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
 import { AdminService } from '@/lib/services/admin';
 import { requireAdmin } from '@/lib/utils/require-admin';
 
@@ -13,7 +13,7 @@ export async function PATCH(
   try {
     const { id } = await params;
     const { action, reason } = await request.json();
-    
+
     const auditContext = {
       adminUserId: auth.userId,
       ipAddress: auth.ipAddress,
@@ -21,7 +21,7 @@ export async function PATCH(
       reason,
     };
 
-    let data;
+    let data: unknown;
     if (action === 'approve') {
       data = await AdminService.approveMerchant(id, auditContext);
     } else if (action === 'reject') {
@@ -31,7 +31,7 @@ export async function PATCH(
     } else {
       return NextResponse.json({ error: 'Invalid action' }, { status: 400 });
     }
-    
+
     return NextResponse.json(data);
   } catch (error) {
     return NextResponse.json(

--- a/apps/web/app/api/admin/merchants/route.ts
+++ b/apps/web/app/api/admin/merchants/route.ts
@@ -1,5 +1,5 @@
-import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
 import { AdminService } from '@/lib/services/admin';
 import { requireAdmin } from '@/lib/utils/require-admin';
 

--- a/apps/web/app/api/auth/confirm/route.ts
+++ b/apps/web/app/api/auth/confirm/route.ts
@@ -1,5 +1,5 @@
-import { createAdminClient } from '@/lib/supabase';
 import { NextResponse } from 'next/server';
+import { createAdminClient } from '@/lib/supabase';
 
 export async function POST(req: Request) {
   try {

--- a/apps/web/app/api/waitlist/request-otp/route.ts
+++ b/apps/web/app/api/waitlist/request-otp/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
-import { z } from 'zod';
 import { Resend } from 'resend';
+import { z } from 'zod';
 import { createAdminClient } from '@/lib/supabase';
 
 const bodySchema = z.object({

--- a/apps/web/app/api/waitlist/submit/route.ts
+++ b/apps/web/app/api/waitlist/submit/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
-import { z } from 'zod';
 import { Resend } from 'resend';
+import { z } from 'zod';
 import { createAdminClient } from '@/lib/supabase';
 
 const bodySchema = z.object({

--- a/apps/web/app/auth/callback/page.tsx
+++ b/apps/web/app/auth/callback/page.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-import { useRouter } from 'next/navigation';
-import { supabase } from '@/lib/supabase';
 import { Loader2 } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import { supabase } from '@/lib/supabase';
 
 /**
  * Handles the redirect from Supabase email confirmation.

--- a/apps/web/app/auth/page.tsx
+++ b/apps/web/app/auth/page.tsx
@@ -2,8 +2,9 @@
 
 import { ArrowLeft, Mail } from 'lucide-react';
 import Link from 'next/link';
-import { useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import { sileo } from 'sileo';
 import { Button } from '@/components/ui/button';
 import {
   Card,
@@ -15,7 +16,6 @@ import {
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { AuthService } from '@/lib/services/auth';
-import { sileo } from 'sileo';
 
 export default function AuthPage() {
   const router = useRouter();

--- a/apps/web/app/dashboard/listings/create/page.tsx
+++ b/apps/web/app/dashboard/listings/create/page.tsx
@@ -1,11 +1,11 @@
 'use client';
 
 import { ArrowLeft } from 'lucide-react';
-import { Button } from '@/components/ui/button';
-import { CreateListingModal } from '@/components/merchant/CreateListingModal';
 import Link from 'next/link';
-import { MerchantGuard } from '@/components/merchant/MerchantGuard';
 import { useRouter } from 'next/navigation';
+import { CreateListingModal } from '@/components/merchant/CreateListingModal';
+import { MerchantGuard } from '@/components/merchant/MerchantGuard';
+import { Button } from '@/components/ui/button';
 
 export default function CreateListingPage() {
   const router = useRouter();

--- a/apps/web/app/dashboard/listings/page.tsx
+++ b/apps/web/app/dashboard/listings/page.tsx
@@ -9,13 +9,13 @@ import {
   MarketStats,
   TradeConfirmationDialog,
 } from '@/components/marketplace';
-import { Button } from '@/components/ui/button';
-import { useCreateEscrow } from '@/hooks/use-escrows';
-import { useAuth } from '@/hooks/use-auth';
-import { useMarketplaceListings } from '@/hooks/use-listings';
-import { filterListings, getMarketStats } from '@/lib/marketplace-utils';
-import { useMerchantStatus } from '@/hooks/useMerchant';
 import { CreateListingModal } from '@/components/merchant/CreateListingModal';
+import { Button } from '@/components/ui/button';
+import { useAuth } from '@/hooks/use-auth';
+import { useCreateEscrow } from '@/hooks/use-escrows';
+import { useMarketplaceListings } from '@/hooks/use-listings';
+import { useMerchantStatus } from '@/hooks/useMerchant';
+import { filterListings, getMarketStats } from '@/lib/marketplace-utils';
 import type {
   ListingFilters,
   MarketplaceListing,
@@ -80,10 +80,14 @@ export default function ListingsPage() {
 
     // Validate amount is within listing bounds
     const minAmount = selectedListing.minAmount || 0;
-    const availableAmount = selectedListing.amountRemaining ?? selectedListing.amount;
+    const availableAmount =
+      selectedListing.amountRemaining ?? selectedListing.amount;
     const maxAvailable =
       selectedListing.maxAmount != null
-        ? Math.min(selectedListing.maxAmount, availableAmount * selectedListing.rate)
+        ? Math.min(
+            selectedListing.maxAmount,
+            availableAmount * selectedListing.rate
+          )
         : availableAmount * selectedListing.rate;
 
     if (fiatAmount < minAmount || fiatAmount > maxAvailable) {
@@ -113,9 +117,13 @@ export default function ListingsPage() {
     // Listing creator's address is stored on the listing at creation time
     const listingCreatorAddress = selectedListing.seller;
 
-    if (!listingCreatorAddress || !isValidStellarAddress(listingCreatorAddress)) {
+    if (
+      !listingCreatorAddress ||
+      !isValidStellarAddress(listingCreatorAddress)
+    ) {
       sileo.error({
-        title: 'This listing does not have a valid Stellar wallet address. The creator needs to recreate it with a connected wallet.',
+        title:
+          'This listing does not have a valid Stellar wallet address. The creator needs to recreate it with a connected wallet.',
       });
       return;
     }
@@ -146,8 +154,14 @@ export default function ListingsPage() {
       amount: cryptoAmount,
       buyer_id,
       seller_id,
-      buyer_uuid: selectedListing.type === 'sell' ? user?.id : selectedListing.creatorUserId,
-      seller_uuid: selectedListing.type === 'sell' ? selectedListing.creatorUserId : user?.id,
+      buyer_uuid:
+        selectedListing.type === 'sell'
+          ? user?.id
+          : selectedListing.creatorUserId,
+      seller_uuid:
+        selectedListing.type === 'sell'
+          ? selectedListing.creatorUserId
+          : user?.id,
       token: selectedListing.token,
       fiat_amount: fiatAmount,
       fiat_currency: selectedListing.fiatCurrency,
@@ -182,10 +196,7 @@ export default function ListingsPage() {
       {isLoading ? (
         <div className="text-muted-foreground">Loading listings...</div>
       ) : (
-        <ListingsTabs
-          listings={filteredListings}
-          onTrade={handleTrade}
-        />
+        <ListingsTabs listings={filteredListings} onTrade={handleTrade} />
       )}
 
       {/* Trade Confirmation Dialog */}

--- a/apps/web/app/dashboard/merchants/page.tsx
+++ b/apps/web/app/dashboard/merchants/page.tsx
@@ -1,11 +1,11 @@
 'use client';
 
+import { AlertTriangle } from 'lucide-react';
 import Image from 'next/image';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
-import { AlertTriangle } from 'lucide-react';
 import { useMeMerchant, usePublicMerchants } from '@/hooks/useMerchant';
 
 export default function MerchantsPage() {

--- a/apps/web/app/dashboard/orders/page.tsx
+++ b/apps/web/app/dashboard/orders/page.tsx
@@ -1,31 +1,36 @@
 'use client';
 
-import { useState, useMemo } from 'react';
-import { ArrowDownLeft, ArrowUpRight, ExternalLink, MessageCircle } from 'lucide-react';
+import type { Escrow } from '@pacto-p2p/types';
 import { useQuery } from '@tanstack/react-query';
-import { useIndexedEscrows } from '@/hooks/use-indexed-escrows';
-import { useUnreadCount } from '@/hooks/use-chat';
-import { useAuth } from '@/hooks/use-auth';
-import useGlobalAuthenticationStore from '@/store/wallet.store';
-import { supabase } from '@/lib/supabase';
-import { useEscrowSelection } from '@/hooks/use-escrow-selection';
-import { useEscrowActions } from '@/hooks/use-escrow-actions';
 import {
+  ArrowDownLeft,
+  ArrowUpRight,
+  ExternalLink,
+  MessageCircle,
+} from 'lucide-react';
+import { useMemo, useState } from 'react';
+import { UnreadBadge } from '@/components/chat/UnreadBadge';
+import {
+  ErrorState,
   EscrowDetailsModal,
   LoadingState,
-  ErrorState,
 } from '@/components/escrow';
-import { UnreadBadge } from '@/components/chat/UnreadBadge';
 import { Button } from '@/components/ui/button';
+import { useAuth } from '@/hooks/use-auth';
+import { useUnreadCount } from '@/hooks/use-chat';
+import { useEscrowActions } from '@/hooks/use-escrow-actions';
+import { useEscrowSelection } from '@/hooks/use-escrow-selection';
+import { useIndexedEscrows } from '@/hooks/use-indexed-escrows';
 import { formatAmount } from '@/lib/dashboard-utils';
-import { getTrustlineName } from '@/utils/getTrustline';
 import {
-  canReportPayment,
   canConfirmPayment,
   canDeposit,
   canReleaseFunds,
+  canReportPayment,
 } from '@/lib/escrow-utils';
-import type { Escrow } from '@pacto-p2p/types';
+import { supabase } from '@/lib/supabase';
+import useGlobalAuthenticationStore from '@/store/wallet.store';
+import { getTrustlineName } from '@/utils/getTrustline';
 
 type RoleTab = 'buyer' | 'seller';
 type StatusTab = 'all' | 'active' | 'completed' | 'disputed';
@@ -44,7 +49,8 @@ export default function EscrowsPage() {
   const { user } = useAuth();
   const { address } = useGlobalAuthenticationStore();
   const { unreadByEngagementId } = useUnreadCount(user?.id ?? null);
-  const { selectedEscrow, selectEscrow, clearSelectedEscrow } = useEscrowSelection();
+  const { selectedEscrow, selectEscrow, clearSelectedEscrow } =
+    useEscrowSelection();
   const {
     isReportPaymentLoading,
     isCancelEscrowLoading,
@@ -67,17 +73,28 @@ export default function EscrowsPage() {
   // Scope the backend-served snapshots to the role selected by the tab,
   // matching the user's wallet address (previously done server-side).
   const escrows = useMemo(
-    () =>
-      address ? allEscrows.filter((e) => e.roles[role] === address) : [],
+    () => (address ? allEscrows.filter((e) => e.roles[role] === address) : []),
     [allEscrows, address, role]
   );
 
-  const engagementIds = useMemo(() => escrows.map((e) => e.engagementId), [escrows]);
+  const engagementIds = useMemo(
+    () => escrows.map((e) => e.engagementId),
+    [escrows]
+  );
 
-  const { data: platformData = { fiatCurrencyMap: {} as Record<string, string>, pactoIds: new Set<string>() } } = useQuery({
+  const {
+    data: platformData = {
+      fiatCurrencyMap: {} as Record<string, string>,
+      pactoIds: new Set<string>(),
+    },
+  } = useQuery({
     queryKey: ['trades-platform-data', engagementIds],
     queryFn: async () => {
-      if (engagementIds.length === 0) return { fiatCurrencyMap: {} as Record<string, string>, pactoIds: new Set<string>() };
+      if (engagementIds.length === 0)
+        return {
+          fiatCurrencyMap: {} as Record<string, string>,
+          pactoIds: new Set<string>(),
+        };
       const { data } = await supabase
         .from('escrows')
         .select('engagement_id, trades(fiat_currency)')
@@ -106,15 +123,24 @@ export default function EscrowsPage() {
     [escrows, pactoIds]
   );
 
-  const counts = useMemo(() => ({
-    all: pactoEscrows.length,
-    active: pactoEscrows.filter((e) => getEscrowStatus(e) === 'active').length,
-    completed: pactoEscrows.filter((e) => getEscrowStatus(e) === 'completed').length,
-    disputed: pactoEscrows.filter((e) => getEscrowStatus(e) === 'disputed').length,
-  }), [pactoEscrows]);
+  const counts = useMemo(
+    () => ({
+      all: pactoEscrows.length,
+      active: pactoEscrows.filter((e) => getEscrowStatus(e) === 'active')
+        .length,
+      completed: pactoEscrows.filter((e) => getEscrowStatus(e) === 'completed')
+        .length,
+      disputed: pactoEscrows.filter((e) => getEscrowStatus(e) === 'disputed')
+        .length,
+    }),
+    [pactoEscrows]
+  );
 
-  const filtered = useMemo(() =>
-    statusTab === 'all' ? pactoEscrows : pactoEscrows.filter((e) => getEscrowStatus(e) === statusTab),
+  const filtered = useMemo(
+    () =>
+      statusTab === 'all'
+        ? pactoEscrows
+        : pactoEscrows.filter((e) => getEscrowStatus(e) === statusTab),
     [pactoEscrows, statusTab]
   );
 
@@ -123,8 +149,10 @@ export default function EscrowsPage() {
     setIsEscrowModalOpen(true);
   };
 
-  const onReportPayment = async (escrow: Escrow) => handleReportPayment(escrow, { evidence: '' });
-  const onConfirmPayment = async (escrow: Escrow) => handleConfirmPayment(escrow);
+  const onReportPayment = async (escrow: Escrow) =>
+    handleReportPayment(escrow, { evidence: '' });
+  const onConfirmPayment = async (escrow: Escrow) =>
+    handleConfirmPayment(escrow);
   const onDeposit = async (escrow: Escrow) => handleDeposit(escrow);
   const onDisputeEscrow = async (escrow: Escrow) => handleDisputeEscrow(escrow);
   const onReleaseFunds = async (escrow: Escrow) => handleReleaseFunds(escrow);
@@ -171,12 +199,14 @@ export default function EscrowsPage() {
 
       {/* Status filter tabs */}
       <div className="flex gap-1 border-b border-white/[0.06] pb-0">
-        {([
-          { key: 'all', label: 'All' },
-          { key: 'active', label: 'In Progress' },
-          { key: 'completed', label: 'Completed' },
-          { key: 'disputed', label: 'Disputed' },
-        ] as { key: StatusTab; label: string }[]).map(({ key, label }) => (
+        {(
+          [
+            { key: 'all', label: 'All' },
+            { key: 'active', label: 'In Progress' },
+            { key: 'completed', label: 'Completed' },
+            { key: 'disputed', label: 'Disputed' },
+          ] as { key: StatusTab; label: string }[]
+        ).map(({ key, label }) => (
           <button
             key={key}
             type="button"
@@ -189,9 +219,13 @@ export default function EscrowsPage() {
           >
             {label}
             {counts[key] > 0 && (
-              <span className={`ml-1.5 text-xs px-1.5 py-0.5 rounded-full ${
-                statusTab === key ? 'bg-emerald-500/20 text-emerald-300' : 'bg-white/[0.08] text-muted-foreground'
-              }`}>
+              <span
+                className={`ml-1.5 text-xs px-1.5 py-0.5 rounded-full ${
+                  statusTab === key
+                    ? 'bg-emerald-500/20 text-emerald-300'
+                    : 'bg-white/[0.08] text-muted-foreground'
+                }`}
+              >
                 {counts[key]}
               </span>
             )}
@@ -207,57 +241,92 @@ export default function EscrowsPage() {
           <>
             {/* Table header */}
             <div className="hidden sm:grid grid-cols-[2fr_1.2fr_1fr_1fr_1fr_100px_64px] gap-6 px-5 py-3 border-b border-white/[0.06]">
-              <p className="text-xs text-muted-foreground/60 uppercase tracking-wide">Order</p>
-              <p className="text-xs text-muted-foreground/60 uppercase tracking-wide pl-10">Counterparty</p>
-              <p className="text-xs text-muted-foreground/60 uppercase tracking-wide">Balance</p>
-              <p className="text-xs text-muted-foreground/60 uppercase tracking-wide -ml-4">Status</p>
-              <p className="text-xs text-muted-foreground/60 uppercase tracking-wide -ml-4">Needed</p>
-              <p className="text-xs text-muted-foreground/60 uppercase tracking-wide -ml-6">Action</p>
-              <p className="text-xs text-muted-foreground/60 uppercase tracking-wide">Viewer</p>
+              <p className="text-xs text-muted-foreground/60 uppercase tracking-wide">
+                Order
+              </p>
+              <p className="text-xs text-muted-foreground/60 uppercase tracking-wide pl-10">
+                Counterparty
+              </p>
+              <p className="text-xs text-muted-foreground/60 uppercase tracking-wide">
+                Balance
+              </p>
+              <p className="text-xs text-muted-foreground/60 uppercase tracking-wide -ml-4">
+                Status
+              </p>
+              <p className="text-xs text-muted-foreground/60 uppercase tracking-wide -ml-4">
+                Needed
+              </p>
+              <p className="text-xs text-muted-foreground/60 uppercase tracking-wide -ml-6">
+                Action
+              </p>
+              <p className="text-xs text-muted-foreground/60 uppercase tracking-wide">
+                Viewer
+              </p>
             </div>
 
             {/* Rows */}
             {filtered.map((escrow, i) => {
               const token = getTrustlineName(escrow.trustline.address);
-              const isCompleted = escrow.flags?.resolved || escrow.flags?.released;
+              const isCompleted =
+                escrow.flags?.resolved || escrow.flags?.released;
               const isDisputed = escrow.flags?.disputed;
-              const counterparty = roleTab === 'buyer' ? escrow.roles.approver : escrow.roles.serviceProvider;
+              const counterparty =
+                roleTab === 'buyer'
+                  ? escrow.roles.approver
+                  : escrow.roles.serviceProvider;
               const unread = unreadByEngagementId[escrow.engagementId] ?? 0;
               const fiatCurrency = fiatCurrencyMap[escrow.engagementId];
-              const tradeLabel = fiatCurrency ? `${token}/${fiatCurrency} P2P Trade` : `${token} P2P Trade`;
+              const tradeLabel = fiatCurrency
+                ? `${token}/${fiatCurrency} P2P Trade`
+                : `${token} P2P Trade`;
 
               const actionNeeded = (() => {
-                if (canDeposit(escrow, roleTab)) return { label: 'Deposit needed', color: 'text-orange-400' };
-                if (canReportPayment(escrow, roleTab)) return { label: 'Pay now', color: 'text-blue-400' };
-                if (canConfirmPayment(escrow, roleTab)) return { label: 'Confirm receipt', color: 'text-blue-400' };
-                if (canReleaseFunds(escrow, roleTab)) return { label: 'Release funds', color: 'text-emerald-400' };
+                if (canDeposit(escrow, roleTab))
+                  return { label: 'Deposit needed', color: 'text-orange-400' };
+                if (canReportPayment(escrow, roleTab))
+                  return { label: 'Pay now', color: 'text-blue-400' };
+                if (canConfirmPayment(escrow, roleTab))
+                  return { label: 'Confirm receipt', color: 'text-blue-400' };
+                if (canReleaseFunds(escrow, roleTab))
+                  return { label: 'Release funds', color: 'text-emerald-400' };
                 return null;
               })();
 
               const statusStyles = isCompleted
                 ? 'bg-emerald-500/10 text-emerald-400 border-emerald-500/20'
                 : isDisputed
-                ? 'bg-red-500/10 text-red-400 border-red-500/20'
-                : 'bg-yellow-500/10 text-yellow-400 border-yellow-500/20';
+                  ? 'bg-red-500/10 text-red-400 border-red-500/20'
+                  : 'bg-yellow-500/10 text-yellow-400 border-yellow-500/20';
 
-              const statusLabel = isCompleted ? 'Completed' : isDisputed ? 'Disputed' : 'In Progress';
+              const statusLabel = isCompleted
+                ? 'Completed'
+                : isDisputed
+                  ? 'Disputed'
+                  : 'In Progress';
 
               return (
                 <div
                   key={escrow.engagementId}
                   className={`grid grid-cols-1 sm:grid-cols-[2fr_1.2fr_1fr_1fr_1fr_100px_64px] gap-6 items-center px-5 py-4 hover:bg-white/[0.03] transition-colors ${
-                    i < filtered.length - 1 ? 'border-b border-white/[0.05]' : ''
+                    i < filtered.length - 1
+                      ? 'border-b border-white/[0.05]'
+                      : ''
                   }`}
                 >
                   {/* Order */}
                   <div className="flex items-center gap-3 min-w-0">
-                    <div className={`w-8 h-8 rounded-lg flex items-center justify-center shrink-0 ${
-                      roleTab === 'buyer' ? 'bg-blue-500/10 text-blue-400' : 'bg-emerald-500/10 text-emerald-400'
-                    }`}>
-                      {roleTab === 'buyer'
-                        ? <ArrowDownLeft className="w-4 h-4" />
-                        : <ArrowUpRight className="w-4 h-4" />
-                      }
+                    <div
+                      className={`w-8 h-8 rounded-lg flex items-center justify-center shrink-0 ${
+                        roleTab === 'buyer'
+                          ? 'bg-blue-500/10 text-blue-400'
+                          : 'bg-emerald-500/10 text-emerald-400'
+                      }`}
+                    >
+                      {roleTab === 'buyer' ? (
+                        <ArrowDownLeft className="w-4 h-4" />
+                      ) : (
+                        <ArrowUpRight className="w-4 h-4" />
+                      )}
                     </div>
                     <div className="min-w-0">
                       <div className="flex items-center gap-2 flex-wrap">
@@ -284,7 +353,9 @@ export default function EscrowsPage() {
 
                   {/* Counterparty */}
                   <div className="pl-12">
-                    <p className="text-xs text-muted-foreground sm:hidden mb-0.5">Counterparty</p>
+                    <p className="text-xs text-muted-foreground sm:hidden mb-0.5">
+                      Counterparty
+                    </p>
                     <p className="font-mono text-xs text-foreground">
                       {counterparty.slice(0, 6)}…{counterparty.slice(-4)}
                     </p>
@@ -292,7 +363,9 @@ export default function EscrowsPage() {
 
                   {/* Balance */}
                   <div>
-                    <p className="text-xs text-muted-foreground sm:hidden mb-0.5">Balance</p>
+                    <p className="text-xs text-muted-foreground sm:hidden mb-0.5">
+                      Balance
+                    </p>
                     <p className="font-mono text-xs text-foreground">
                       {formatAmount(escrow.balance ?? 0)} {token}
                     </p>
@@ -300,7 +373,9 @@ export default function EscrowsPage() {
 
                   {/* Status */}
                   <div className="-ml-8">
-                    <span className={`text-xs font-semibold px-2.5 py-1 rounded-full border ${statusStyles}`}>
+                    <span
+                      className={`text-xs font-semibold px-2.5 py-1 rounded-full border ${statusStyles}`}
+                    >
                       {statusLabel}
                     </span>
                   </div>
@@ -308,11 +383,15 @@ export default function EscrowsPage() {
                   {/* Needed */}
                   <div className="-ml-4">
                     {actionNeeded && !isCompleted && !isDisputed ? (
-                      <span className={`text-xs font-medium ${actionNeeded.color}`}>
+                      <span
+                        className={`text-xs font-medium ${actionNeeded.color}`}
+                      >
                         {actionNeeded.label}
                       </span>
                     ) : (
-                      <span className="text-xs text-muted-foreground/30">—</span>
+                      <span className="text-xs text-muted-foreground/30">
+                        —
+                      </span>
                     )}
                   </div>
 
@@ -337,7 +416,10 @@ export default function EscrowsPage() {
                         className="text-muted-foreground hover:text-emerald-400 px-2 h-8"
                         onClick={(e) => {
                           e.stopPropagation();
-                          window.open(`https://viewer.trustlesswork.com/${escrow.contractId}`, '_blank');
+                          window.open(
+                            `https://viewer.trustlesswork.com/${escrow.contractId}`,
+                            '_blank'
+                          );
                         }}
                       >
                         <ExternalLink className="w-3.5 h-3.5" />
@@ -374,7 +456,13 @@ export default function EscrowsPage() {
   );
 }
 
-function EmptyTableState({ roleTab, statusTab }: { roleTab: RoleTab; statusTab: StatusTab }) {
+function EmptyTableState({
+  roleTab,
+  statusTab,
+}: {
+  roleTab: RoleTab;
+  statusTab: StatusTab;
+}) {
   const messages: Record<StatusTab, string> = {
     all: `No ${roleTab} orders yet`,
     active: 'No orders in progress',

--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -1,24 +1,24 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
-import Link from 'next/link';
 import {
+  AlertTriangle,
   ArrowUpRight,
   CheckCircle2,
   Clock,
   Shield,
   TrendingUp,
-  AlertTriangle,
 } from 'lucide-react';
-import { useAuth } from '@/hooks/use-auth';
-import { useTrades } from '@/hooks/use-trades-history';
-import { useUserListings } from '@/hooks/use-listings';
-import { useMerchantStatus } from '@/hooks/useMerchant';
-import { useEscrowsByRoleQuery } from '@/hooks/use-escrows';
-import { usePactoEscrowIds } from '@/hooks/use-pacto-escrow-ids';
+import Link from 'next/link';
+import { useEffect, useMemo, useState } from 'react';
 import { WalletConnectionPrompt } from '@/components/shared/WalletConnectionPrompt';
-import useGlobalAuthenticationStore from '@/store/wallet.store';
+import { useAuth } from '@/hooks/use-auth';
+import { useEscrowsByRoleQuery } from '@/hooks/use-escrows';
+import { useUserListings } from '@/hooks/use-listings';
+import { usePactoEscrowIds } from '@/hooks/use-pacto-escrow-ids';
+import { useTrades } from '@/hooks/use-trades-history';
+import { useMerchantStatus } from '@/hooks/useMerchant';
 import { formatAmount } from '@/lib/dashboard-utils';
+import useGlobalAuthenticationStore from '@/store/wallet.store';
 import { getTrustlineName } from '@/utils/getTrustline';
 
 export default function DashboardPage() {
@@ -55,22 +55,31 @@ export default function DashboardPage() {
   const pactoIds = usePactoEscrowIds(allEngagementIds);
 
   const allPactoEscrows = useMemo(
-    () => [...sellerEscrows, ...buyerEscrows].filter((e) => pactoIds.has(e.engagementId)),
+    () =>
+      [...sellerEscrows, ...buyerEscrows].filter((e) =>
+        pactoIds.has(e.engagementId)
+      ),
     [sellerEscrows, buyerEscrows, pactoIds]
   );
 
   const activeOrders = allPactoEscrows.filter(
     (e) => !e.flags?.released && !e.flags?.resolved
   ).length;
-  const activeListings = userListings.filter((l) => l.status === 'active').length;
-  const completedTrades = trades.filter((t) => t.status === 'completed' || t.status === 'resolved').length;
+  const activeListings = userListings.filter(
+    (l) => l.status === 'active'
+  ).length;
+  const completedTrades = trades.filter(
+    (t) => t.status === 'completed' || t.status === 'resolved'
+  ).length;
   const totalVolume = trades
     .filter((t) => t.status === 'completed' || t.status === 'resolved')
     .reduce((sum, t) => sum + (t.amount ?? 0), 0);
   const activeEscrows = allPactoEscrows
     .filter((e) => !e.flags?.released && !e.flags?.resolved)
     .slice(0, 3);
-  const recentCompletedTrades = trades.filter((t) => t.status === 'completed' || t.status === 'resolved').slice(0, 4);
+  const recentCompletedTrades = trades
+    .filter((t) => t.status === 'completed' || t.status === 'resolved')
+    .slice(0, 4);
 
   const displayName =
     user?.full_name || user?.username || user?.email?.split('@')[0] || 'Trader';
@@ -85,25 +94,41 @@ export default function DashboardPage() {
   useEffect(() => {
     if (userDismissedPrompt || showWalletPrompt) return;
     if (isConnected && address && user?.stellar_address === address) return;
-    if (!authLoading && user && !user.stellar_address && !hasShownWalletPrompt && !(isConnected && address)) {
+    if (
+      !authLoading &&
+      user &&
+      !user.stellar_address &&
+      !hasShownWalletPrompt &&
+      !(isConnected && address)
+    ) {
       const timer = setTimeout(() => {
         setShowWalletPrompt(true);
         setHasShownWalletPrompt(true);
       }, 1000);
       return () => clearTimeout(timer);
     }
-  }, [user, authLoading, showWalletPrompt, isConnected, address, hasShownWalletPrompt, userDismissedPrompt]);
+  }, [
+    user,
+    authLoading,
+    showWalletPrompt,
+    isConnected,
+    address,
+    hasShownWalletPrompt,
+    userDismissedPrompt,
+  ]);
 
   const handleWalletPromptChange = (open: boolean) => {
     setShowWalletPrompt(open);
-    if (!open && (!isConnected || !address || user?.stellar_address !== address)) {
+    if (
+      !open &&
+      (!isConnected || !address || user?.stellar_address !== address)
+    ) {
       setUserDismissedPrompt(true);
     }
   };
 
   return (
     <div className="space-y-4">
-
       {/* ── Welcome ── */}
       <div className="flex flex-col sm:flex-row sm:items-center gap-3 px-1">
         <div>
@@ -152,12 +177,14 @@ export default function DashboardPage() {
 
       {/* ── Bottom row: active orders preview + recent trades ── */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-
         {/* Active orders preview */}
         <div className="rounded-2xl bg-white/[0.03] border border-white/[0.07] overflow-hidden">
           <div className="flex items-center justify-between px-5 py-4 border-b border-white/[0.06]">
             <p className="text-sm font-semibold text-white">Active orders</p>
-            <Link href="/dashboard/orders" className="text-xs text-muted-foreground hover:text-white transition-colors flex items-center gap-1">
+            <Link
+              href="/dashboard/orders"
+              className="text-xs text-muted-foreground hover:text-white transition-colors flex items-center gap-1"
+            >
               View all <ArrowUpRight className="w-3 h-3" />
             </Link>
           </div>
@@ -173,20 +200,26 @@ export default function DashboardPage() {
                   <div
                     key={escrow.engagementId}
                     className={`flex items-center justify-between px-5 py-3.5 hover:bg-white/[0.03] transition-colors ${
-                      i < activeEscrows.length - 1 ? 'border-b border-white/[0.04]' : ''
+                      i < activeEscrows.length - 1
+                        ? 'border-b border-white/[0.04]'
+                        : ''
                     }`}
                   >
                     <div className="flex items-center gap-3 min-w-0">
                       <Clock className="w-3.5 h-3.5 text-yellow-400 shrink-0" />
                       <span className="text-sm text-foreground font-medium">
                         {formatAmount(Number(escrow.amount) ?? 0)}{' '}
-                        <span className="text-muted-foreground font-normal">{getTrustlineName(escrow.trustline?.address ?? '')}</span>
+                        <span className="text-muted-foreground font-normal">
+                          {getTrustlineName(escrow.trustline?.address ?? '')}
+                        </span>
                       </span>
                       <span className="text-xs text-muted-foreground/60 capitalize hidden sm:inline">
                         {isSeller ? 'sell' : 'buy'}
                       </span>
                     </div>
-                    <span className="text-xs font-medium text-yellow-400 shrink-0">In progress</span>
+                    <span className="text-xs font-medium text-yellow-400 shrink-0">
+                      In progress
+                    </span>
                   </div>
                 );
               })}
@@ -198,7 +231,10 @@ export default function DashboardPage() {
         <div className="rounded-2xl bg-white/[0.03] border border-white/[0.07] overflow-hidden">
           <div className="flex items-center justify-between px-5 py-4 border-b border-white/[0.06]">
             <p className="text-sm font-semibold text-white">Recent trades</p>
-            <Link href="/dashboard/orders" className="text-xs text-muted-foreground hover:text-white transition-colors flex items-center gap-1">
+            <Link
+              href="/dashboard/orders"
+              className="text-xs text-muted-foreground hover:text-white transition-colors flex items-center gap-1"
+            >
               View all <ArrowUpRight className="w-3 h-3" />
             </Link>
           </div>
@@ -209,35 +245,51 @@ export default function DashboardPage() {
           ) : (
             <div>
               {recentCompletedTrades.map((trade, i) => {
-                const isCompleted = trade.status === 'completed' || trade.status === 'resolved';
+                const isCompleted =
+                  trade.status === 'completed' || trade.status === 'resolved';
                 const isDisputed = trade.status === 'disputed';
                 const isActive = trade.status === 'active';
                 return (
                   <div
                     key={trade.id}
                     className={`flex items-center justify-between px-5 py-3.5 hover:bg-white/[0.03] transition-colors ${
-                      i < recentCompletedTrades.length - 1 ? 'border-b border-white/[0.04]' : ''
+                      i < recentCompletedTrades.length - 1
+                        ? 'border-b border-white/[0.04]'
+                        : ''
                     }`}
                   >
                     <div className="flex items-center gap-3">
-                      {isCompleted
-                        ? <CheckCircle2 className="w-3.5 h-3.5 text-emerald-400 shrink-0" />
-                        : isDisputed
-                        ? <AlertTriangle className="w-3.5 h-3.5 text-red-400 shrink-0" />
-                        : <Clock className="w-3.5 h-3.5 text-yellow-400 shrink-0" />
-                      }
+                      {isCompleted ? (
+                        <CheckCircle2 className="w-3.5 h-3.5 text-emerald-400 shrink-0" />
+                      ) : isDisputed ? (
+                        <AlertTriangle className="w-3.5 h-3.5 text-red-400 shrink-0" />
+                      ) : (
+                        <Clock className="w-3.5 h-3.5 text-yellow-400 shrink-0" />
+                      )}
                       <span className="text-sm text-foreground">
                         {formatAmount(trade.amount ?? 0)}{' '}
-                        <span className="text-muted-foreground">{trade.token}</span>
+                        <span className="text-muted-foreground">
+                          {trade.token}
+                        </span>
                       </span>
                       <span className="text-xs text-muted-foreground/60 capitalize hidden sm:inline">
                         {trade.type}
                       </span>
                     </div>
-                    <span className={`text-xs ${
-                      isCompleted ? 'text-emerald-400' : isDisputed ? 'text-red-400' : 'text-yellow-400'
-                    }`}>
-                      {isCompleted ? 'Completed' : isDisputed ? 'Disputed' : 'In progress'}
+                    <span
+                      className={`text-xs ${
+                        isCompleted
+                          ? 'text-emerald-400'
+                          : isDisputed
+                            ? 'text-red-400'
+                            : 'text-yellow-400'
+                      }`}
+                    >
+                      {isCompleted
+                        ? 'Completed'
+                        : isDisputed
+                          ? 'Disputed'
+                          : 'In progress'}
                     </span>
                   </div>
                 );
@@ -247,7 +299,10 @@ export default function DashboardPage() {
         </div>
       </div>
 
-      <WalletConnectionPrompt open={showWalletPrompt} onOpenChange={handleWalletPromptChange} />
+      <WalletConnectionPrompt
+        open={showWalletPrompt}
+        onOpenChange={handleWalletPromptChange}
+      />
     </div>
   );
 }
@@ -266,22 +321,32 @@ function StatTile({
   href?: string;
 }) {
   const tile = (
-    <div className={`rounded-2xl border p-5 flex flex-col gap-3 transition-all duration-200 ${
-      accent
-        ? 'bg-emerald-500/10 border-emerald-500/25 hover:bg-emerald-500/15'
-        : 'bg-white/[0.03] border-white/[0.07] hover:bg-white/[0.05]'
-    } ${href ? 'cursor-pointer' : ''}`}>
+    <div
+      className={`rounded-2xl border p-5 flex flex-col gap-3 transition-all duration-200 ${
+        accent
+          ? 'bg-emerald-500/10 border-emerald-500/25 hover:bg-emerald-500/15'
+          : 'bg-white/[0.03] border-white/[0.07] hover:bg-white/[0.05]'
+      } ${href ? 'cursor-pointer' : ''}`}
+    >
       <div className="flex items-center justify-between">
-        <div className={`w-8 h-8 rounded-lg flex items-center justify-center shrink-0 ${
-          accent ? 'bg-emerald-500/20 text-emerald-400' : 'bg-white/[0.06] text-muted-foreground'
-        }`}>
+        <div
+          className={`w-8 h-8 rounded-lg flex items-center justify-center shrink-0 ${
+            accent
+              ? 'bg-emerald-500/20 text-emerald-400'
+              : 'bg-white/[0.06] text-muted-foreground'
+          }`}
+        >
           {icon}
         </div>
-        {href && <ArrowUpRight className="w-3.5 h-3.5 text-muted-foreground/30" />}
+        {href && (
+          <ArrowUpRight className="w-3.5 h-3.5 text-muted-foreground/30" />
+        )}
       </div>
       <div>
         <p className="text-xs text-muted-foreground mb-1">{label}</p>
-        <p className={`text-3xl font-bold leading-none truncate ${accent ? 'text-emerald-400' : 'text-white'}`}>
+        <p
+          className={`text-3xl font-bold leading-none truncate ${accent ? 'text-emerald-400' : 'text-white'}`}
+        >
           {value}
         </p>
       </div>

--- a/apps/web/app/dashboard/profile/page.tsx
+++ b/apps/web/app/dashboard/profile/page.tsx
@@ -1,11 +1,9 @@
 'use client';
 
 import { Settings } from 'lucide-react';
-import { Suspense, useState, useMemo, useCallback } from 'react';
 import { useSearchParams } from 'next/navigation';
+import { Suspense, useCallback, useMemo, useState } from 'react';
 import { sileo } from 'sileo';
-import { Button } from '@/components/ui/button';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import {
   MerchantSection,
   NotificationSettings,
@@ -15,10 +13,12 @@ import {
   SecuritySettings,
 } from '@/components/profile';
 import type { UserData } from '@/components/profile/types';
-import type { User } from '@/lib/types';
+import { Button } from '@/components/ui/button';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { useAuth } from '@/hooks/use-auth';
-import { EnhancedAuthService } from '@/lib/services/enhanced-auth.service';
 import { validateProfileUpdate } from '@/lib/schemas/profile-validation.schema';
+import { EnhancedAuthService } from '@/lib/services/enhanced-auth.service';
+import type { User } from '@/lib/types';
 
 const TAB_TRIGGER_CLASS =
   'bg-card/60 hover:bg-card/80 active:bg-card/90 text-muted-foreground hover:text-foreground data-[state=active]:bg-emerald-500 data-[state=active]:text-white data-[state=active]:shadow-md data-[state=active]:border-emerald-600 transition-all duration-200 rounded-md px-4 py-1.5 text-sm font-medium border border-transparent cursor-pointer whitespace-nowrap';

--- a/apps/web/app/dashboard/wallet/page.tsx
+++ b/apps/web/app/dashboard/wallet/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Wallet } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 
 export default function WalletPage() {
   return (

--- a/apps/web/app/m/[slug]/page.tsx
+++ b/apps/web/app/m/[slug]/page.tsx
@@ -1,7 +1,15 @@
-import { Suspense } from 'react';
 import { ArrowLeft } from 'lucide-react';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
+import { Suspense } from 'react';
+import {
+  BadgesGridSkeleton,
+  KpiCardsSkeleton,
+  ListingsTableSkeleton,
+  MerchantHeroSkeleton,
+  SpeedHistogramSkeleton,
+  VolumeChartSkeleton,
+} from '@/app/m/[slug]/_components/MerchantSkeletons';
 import { BadgeGrid } from '@/components/merchant/BadgeGrid';
 import { KpiCards } from '@/components/merchant/KpiCards';
 import { ListingsTable } from '@/components/merchant/ListingsTable';
@@ -19,14 +27,6 @@ import type {
   SpeedBucket,
   VolumePoint,
 } from '@/lib/types/merchant';
-import {
-  BadgesGridSkeleton,
-  KpiCardsSkeleton,
-  ListingsTableSkeleton,
-  MerchantHeroSkeleton,
-  SpeedHistogramSkeleton,
-  VolumeChartSkeleton,
-} from '@/app/m/[slug]/_components/MerchantSkeletons';
 
 export default async function Page({
   params,

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Aurora from '@/components/Aurora';
 import {
   AssetsSection,
   BuildersSection,
@@ -11,7 +12,6 @@ import {
   HeroSection,
   HowItWorksSection,
 } from '@/components/landing';
-import Aurora from '@/components/Aurora';
 
 export default function HomePage() {
   return (

--- a/apps/web/components/Aurora.tsx
+++ b/apps/web/components/Aurora.tsx
@@ -1,5 +1,5 @@
+import { Color, Mesh, Program, Renderer, Triangle } from 'ogl';
 import { useEffect, useRef } from 'react';
-import { Renderer, Program, Mesh, Color, Triangle } from 'ogl';
 
 const VERT = `#version 300 es
 in vec2 position;

--- a/apps/web/components/RotatingText.tsx
+++ b/apps/web/components/RotatingText.tsx
@@ -1,4 +1,12 @@
 import {
+  AnimatePresence,
+  motion,
+  type Target,
+  type TargetAndTransition,
+  type Transition,
+  type VariantLabels,
+} from 'motion/react';
+import {
   forwardRef,
   useCallback,
   useEffect,
@@ -6,14 +14,6 @@ import {
   useMemo,
   useState,
 } from 'react';
-import {
-  motion,
-  AnimatePresence,
-  type Transition,
-  type VariantLabels,
-  type Target,
-  type TargetAndTransition,
-} from 'motion/react';
 
 function cn(...classes: (string | undefined | null | boolean)[]): string {
   return classes.filter(Boolean).join(' ');

--- a/apps/web/components/admin/DisputeManagement.tsx
+++ b/apps/web/components/admin/DisputeManagement.tsx
@@ -1,12 +1,12 @@
 'use client';
 
-import { useState } from 'react';
+import type { Escrow } from '@pacto-p2p/types';
 import { Loader2, Scale } from 'lucide-react';
+import { useState } from 'react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { useDisputedEscrows } from '@/hooks/use-disputed-escrows';
 import { DisputeResolutionModal } from './DisputeResolutionModal';
-import type { Escrow } from '@pacto-p2p/types';
 
 export function DisputeManagement() {
   const { data: escrows, isLoading, error, refetch } = useDisputedEscrows();

--- a/apps/web/components/admin/DisputeResolutionModal.tsx
+++ b/apps/web/components/admin/DisputeResolutionModal.tsx
@@ -1,18 +1,18 @@
 'use client';
 
-import { useState } from 'react';
+import type { Escrow } from '@pacto-p2p/types';
 import { AlertTriangle, Loader2, ShieldAlert } from 'lucide-react';
+import { useState } from 'react';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
-  DialogDescription,
 } from '@/components/ui/dialog';
-import type { Escrow } from '@pacto-p2p/types';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 import { useEscrowActions } from '@/hooks/use-escrow-actions';
 import useGlobalAuthenticationStore from '@/store/wallet.store';
 
@@ -109,7 +109,8 @@ export function DisputeResolutionModal({
             <div className="flex items-start gap-2 rounded-lg border border-yellow-500/40 bg-yellow-500/10 p-3 text-sm text-yellow-700 dark:text-yellow-400">
               <ShieldAlert className="mt-0.5 h-4 w-4 shrink-0" />
               <span>
-                Connect the platform wallet ({platformAddress || 'not configured'}) to resolve disputes.
+                Connect the platform wallet (
+                {platformAddress || 'not configured'}) to resolve disputes.
                 Currently connected: {address || 'none'}
               </span>
             </div>

--- a/apps/web/components/admin/MerchantApplicationModal.tsx
+++ b/apps/web/components/admin/MerchantApplicationModal.tsx
@@ -1,19 +1,20 @@
 'use client';
 
-import { useState } from 'react';
 import {
+  Ban,
   Calendar,
-  Mail,
-  User,
-  MapPin,
+  CheckCircle,
+  DollarSign,
   Globe,
+  Mail,
+  MapPin,
   Star,
   TrendingUp,
-  DollarSign,
-  CheckCircle,
+  User,
   XCircle,
-  Ban,
 } from 'lucide-react';
+import { useState } from 'react';
+import { toast } from 'sonner';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
@@ -24,14 +25,13 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
-import { Textarea } from '@/components/ui/textarea';
 import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
 import {
   useApproveMerchant,
   useRejectMerchant,
   useRevokeMerchant,
 } from '@/hooks/use-admin';
-import { toast } from 'sonner';
 import type { MerchantApplication } from '@/lib/types/admin';
 
 type PendingAction = 'reject' | 'revoke' | null;
@@ -83,17 +83,27 @@ export function MerchantApplicationModal({
     if (!pendingAction || !statusMessage.trim()) return;
     try {
       if (pendingAction === 'reject') {
-        await rejectMutation.mutateAsync({ id: application.id, reason: statusMessage.trim() });
+        await rejectMutation.mutateAsync({
+          id: application.id,
+          reason: statusMessage.trim(),
+        });
         toast.success('Merchant application rejected');
       } else {
-        await revokeMutation.mutateAsync({ id: application.id, reason: statusMessage.trim() });
+        await revokeMutation.mutateAsync({
+          id: application.id,
+          reason: statusMessage.trim(),
+        });
         toast.success('Merchant verification revoked');
       }
       setPendingAction(null);
       setStatusMessage('');
       handleClose();
     } catch (error) {
-      toast.error(pendingAction === 'reject' ? 'Failed to reject merchant application' : 'Failed to revoke merchant verification');
+      toast.error(
+        pendingAction === 'reject'
+          ? 'Failed to reject merchant application'
+          : 'Failed to revoke merchant verification'
+      );
       console.error(error);
     }
   };
@@ -107,204 +117,261 @@ export function MerchantApplicationModal({
 
   return (
     <>
-    <Dialog
-      open={pendingAction !== null}
-      onOpenChange={(open) => { if (!open) { setPendingAction(null); setStatusMessage(''); } }}
-    >
-      <DialogContent className="max-w-md">
-        <DialogHeader>
-          <DialogTitle>
-            {pendingAction === 'reject' ? 'Reject Application' : 'Revoke Verification'}
-          </DialogTitle>
-          <DialogDescription>
-            {pendingAction === 'reject'
-              ? 'Provide a reason so the merchant knows what to improve.'
-              : 'Provide a reason for revoking this merchant\'s verification.'}
-          </DialogDescription>
-        </DialogHeader>
-        <div className="space-y-2 py-2">
-          <Label htmlFor="status-message">
-            Reason <span className="text-destructive">*</span>
-          </Label>
-          <Textarea
-            id="status-message"
-            placeholder="e.g. Your profile bio is incomplete. Please add more details about your trading experience."
-            value={statusMessage}
-            onChange={(e) => setStatusMessage(e.target.value)}
-            rows={4}
-          />
-        </div>
-        <DialogFooter>
-          <Button
-            variant="ghost"
-            onClick={() => { setPendingAction(null); setStatusMessage(''); }}
-            disabled={isConfirming}
-          >
-            Cancel
-          </Button>
-          <Button
-            variant="destructive"
-            onClick={handleConfirmAction}
-            disabled={!statusMessage.trim() || isConfirming}
-          >
-            {isConfirming ? 'Processing...' : pendingAction === 'reject' ? 'Reject' : 'Revoke'}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
-
-    <Dialog open={isOpen} onOpenChange={handleClose}>
-      <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
-        <DialogHeader>
-          <div className="flex items-start justify-between">
-            <div>
-              <DialogTitle className="text-2xl">
-                {application.display_name}
-              </DialogTitle>
-              <DialogDescription>@{application.slug}</DialogDescription>
-            </div>
-            <Badge
-              variant="outline"
-              className={statusVariants[application.verification_status]}
+      <Dialog
+        open={pendingAction !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setPendingAction(null);
+            setStatusMessage('');
+          }
+        }}
+      >
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>
+              {pendingAction === 'reject'
+                ? 'Reject Application'
+                : 'Revoke Verification'}
+            </DialogTitle>
+            <DialogDescription>
+              {pendingAction === 'reject'
+                ? 'Provide a reason so the merchant knows what to improve.'
+                : "Provide a reason for revoking this merchant's verification."}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2 py-2">
+            <Label htmlFor="status-message">
+              Reason <span className="text-destructive">*</span>
+            </Label>
+            <Textarea
+              id="status-message"
+              placeholder="e.g. Your profile bio is incomplete. Please add more details about your trading experience."
+              value={statusMessage}
+              onChange={(e) => setStatusMessage(e.target.value)}
+              rows={4}
+            />
+          </div>
+          <DialogFooter>
+            <Button
+              variant="ghost"
+              onClick={() => {
+                setPendingAction(null);
+                setStatusMessage('');
+              }}
+              disabled={isConfirming}
             >
-              {application.verification_status}
-            </Badge>
-          </div>
-        </DialogHeader>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={handleConfirmAction}
+              disabled={!statusMessage.trim() || isConfirming}
+            >
+              {isConfirming
+                ? 'Processing...'
+                : pendingAction === 'reject'
+                  ? 'Reject'
+                  : 'Revoke'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
-        <div className="space-y-6 py-4">
-          {/* User Information */}
-          <div className="space-y-3">
-            <h3 className="font-semibold text-lg">User Information</h3>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-3 text-sm">
-              <div className="flex items-center gap-2">
-                <Mail className="w-4 h-4 text-gray-500" />
-                <span className="text-gray-600">Email:</span>
-                <span className="font-medium">
-                  {application.user?.email || 'N/A'}
-                </span>
-              </div>
-              <div className="flex items-center gap-2">
-                <User className="w-4 h-4 text-gray-500" />
-                <span className="text-gray-600">Name:</span>
-                <span className="font-medium">
-                  {application.user?.full_name || 'N/A'}
-                </span>
-              </div>
-              <div className="flex items-center gap-2">
-                <Calendar className="w-4 h-4 text-gray-500" />
-                <span className="text-gray-600">User Since:</span>
-                <span className="font-medium">
-                  {application.user?.created_at
-                    ? new Date(application.user.created_at).toLocaleDateString()
-                    : 'N/A'}
-                </span>
-              </div>
-              <div className="flex items-center gap-2">
-                <Calendar className="w-4 h-4 text-gray-500" />
-                <span className="text-gray-600">Applied:</span>
-                <span className="font-medium">
-                  {new Date(application.created_at).toLocaleDateString()}
-                </span>
-              </div>
-            </div>
-          </div>
-
-          {/* Merchant Profile */}
-          <div className="space-y-3">
-            <h3 className="font-semibold text-lg">Merchant Profile</h3>
-            {application.bio && (
+      <Dialog open={isOpen} onOpenChange={handleClose}>
+        <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+          <DialogHeader>
+            <div className="flex items-start justify-between">
               <div>
-                <p className="text-sm text-gray-600 mb-1">Bio:</p>
-                <p className="text-sm">{application.bio}</p>
+                <DialogTitle className="text-2xl">
+                  {application.display_name}
+                </DialogTitle>
+                <DialogDescription>@{application.slug}</DialogDescription>
               </div>
-            )}
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-3 text-sm">
-              {application.location && (
+              <Badge
+                variant="outline"
+                className={statusVariants[application.verification_status]}
+              >
+                {application.verification_status}
+              </Badge>
+            </div>
+          </DialogHeader>
+
+          <div className="space-y-6 py-4">
+            {/* User Information */}
+            <div className="space-y-3">
+              <h3 className="font-semibold text-lg">User Information</h3>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-3 text-sm">
                 <div className="flex items-center gap-2">
-                  <MapPin className="w-4 h-4 text-gray-500" />
-                  <span className="text-gray-600">Location:</span>
-                  <span className="font-medium">{application.location}</span>
-                </div>
-              )}
-              {application.languages && application.languages.length > 0 && (
-                <div className="flex items-center gap-2">
-                  <Globe className="w-4 h-4 text-gray-500" />
-                  <span className="text-gray-600">Languages:</span>
+                  <Mail className="w-4 h-4 text-gray-500" />
+                  <span className="text-gray-600">Email:</span>
                   <span className="font-medium">
-                    {application.languages.join(', ')}
+                    {application.user?.email || 'N/A'}
                   </span>
                 </div>
+                <div className="flex items-center gap-2">
+                  <User className="w-4 h-4 text-gray-500" />
+                  <span className="text-gray-600">Name:</span>
+                  <span className="font-medium">
+                    {application.user?.full_name || 'N/A'}
+                  </span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Calendar className="w-4 h-4 text-gray-500" />
+                  <span className="text-gray-600">User Since:</span>
+                  <span className="font-medium">
+                    {application.user?.created_at
+                      ? new Date(
+                          application.user.created_at
+                        ).toLocaleDateString()
+                      : 'N/A'}
+                  </span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Calendar className="w-4 h-4 text-gray-500" />
+                  <span className="text-gray-600">Applied:</span>
+                  <span className="font-medium">
+                    {new Date(application.created_at).toLocaleDateString()}
+                  </span>
+                </div>
+              </div>
+            </div>
+
+            {/* Merchant Profile */}
+            <div className="space-y-3">
+              <h3 className="font-semibold text-lg">Merchant Profile</h3>
+              {application.bio && (
+                <div>
+                  <p className="text-sm text-gray-600 mb-1">Bio:</p>
+                  <p className="text-sm">{application.bio}</p>
+                </div>
               )}
-            </div>
-          </div>
-
-          {/* Social Links */}
-          {application.socials &&
-            Object.keys(application.socials).length > 0 && (
-              <div className="space-y-3">
-                <h3 className="font-semibold text-lg">Social Links</h3>
-                <div className="grid grid-cols-1 gap-2 text-sm">
-                  {Object.entries(application.socials).map(
-                    ([platform, url]) => (
-                      <div key={platform} className="flex items-center gap-2">
-                        <Globe className="w-4 h-4 text-gray-500" />
-                        <span className="text-gray-600 capitalize">
-                          {platform}:
-                        </span>
-                        <a
-                          href={url}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="text-blue-600 hover:underline font-medium"
-                        >
-                          {url}
-                        </a>
-                      </div>
-                    )
-                  )}
-                </div>
-              </div>
-            )}
-
-          {/* Trading Stats */}
-          <div className="space-y-3">
-            <h3 className="font-semibold text-lg">Trading Statistics</h3>
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-              <div className="bg-black border border-white rounded-lg p-4">
-                <div className="flex items-center gap-2 text-gray-400 mb-1">
-                  <Star className="w-4 h-4" />
-                  <span className="text-sm">Rating</span>
-                </div>
-                <p className="text-2xl font-bold text-white">
-                  {application.rating.toFixed(1)}
-                </p>
-              </div>
-              <div className="bg-black border border-white rounded-lg p-4">
-                <div className="flex items-center gap-2 text-gray-400 mb-1">
-                  <TrendingUp className="w-4 h-4" />
-                  <span className="text-sm">Total Trades</span>
-                </div>
-                <p className="text-2xl font-bold text-white">
-                  {application.total_trades}
-                </p>
-              </div>
-              <div className="bg-black border border-white rounded-lg p-4">
-                <div className="flex items-center gap-2 text-gray-400 mb-1">
-                  <DollarSign className="w-4 h-4" />
-                  <span className="text-sm">Volume Traded</span>
-                </div>
-                <p className="text-2xl font-bold text-white">
-                  ${application.volume_traded.toLocaleString()}
-                </p>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-3 text-sm">
+                {application.location && (
+                  <div className="flex items-center gap-2">
+                    <MapPin className="w-4 h-4 text-gray-500" />
+                    <span className="text-gray-600">Location:</span>
+                    <span className="font-medium">{application.location}</span>
+                  </div>
+                )}
+                {application.languages && application.languages.length > 0 && (
+                  <div className="flex items-center gap-2">
+                    <Globe className="w-4 h-4 text-gray-500" />
+                    <span className="text-gray-600">Languages:</span>
+                    <span className="font-medium">
+                      {application.languages.join(', ')}
+                    </span>
+                  </div>
+                )}
               </div>
             </div>
-          </div>
 
-          {/* Action Buttons */}
-          <div className="flex gap-3 pt-4 border-t">
-            {application.verification_status === 'pending' && (
-              <>
+            {/* Social Links */}
+            {application.socials &&
+              Object.keys(application.socials).length > 0 && (
+                <div className="space-y-3">
+                  <h3 className="font-semibold text-lg">Social Links</h3>
+                  <div className="grid grid-cols-1 gap-2 text-sm">
+                    {Object.entries(application.socials).map(
+                      ([platform, url]) => (
+                        <div key={platform} className="flex items-center gap-2">
+                          <Globe className="w-4 h-4 text-gray-500" />
+                          <span className="text-gray-600 capitalize">
+                            {platform}:
+                          </span>
+                          <a
+                            href={url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-blue-600 hover:underline font-medium"
+                          >
+                            {url}
+                          </a>
+                        </div>
+                      )
+                    )}
+                  </div>
+                </div>
+              )}
+
+            {/* Trading Stats */}
+            <div className="space-y-3">
+              <h3 className="font-semibold text-lg">Trading Statistics</h3>
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                <div className="bg-black border border-white rounded-lg p-4">
+                  <div className="flex items-center gap-2 text-gray-400 mb-1">
+                    <Star className="w-4 h-4" />
+                    <span className="text-sm">Rating</span>
+                  </div>
+                  <p className="text-2xl font-bold text-white">
+                    {application.rating.toFixed(1)}
+                  </p>
+                </div>
+                <div className="bg-black border border-white rounded-lg p-4">
+                  <div className="flex items-center gap-2 text-gray-400 mb-1">
+                    <TrendingUp className="w-4 h-4" />
+                    <span className="text-sm">Total Trades</span>
+                  </div>
+                  <p className="text-2xl font-bold text-white">
+                    {application.total_trades}
+                  </p>
+                </div>
+                <div className="bg-black border border-white rounded-lg p-4">
+                  <div className="flex items-center gap-2 text-gray-400 mb-1">
+                    <DollarSign className="w-4 h-4" />
+                    <span className="text-sm">Volume Traded</span>
+                  </div>
+                  <p className="text-2xl font-bold text-white">
+                    ${application.volume_traded.toLocaleString()}
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            {/* Action Buttons */}
+            <div className="flex gap-3 pt-4 border-t">
+              {application.verification_status === 'pending' && (
+                <>
+                  <Button
+                    onClick={handleApprove}
+                    disabled={isLoading}
+                    className="btn-emerald flex-1"
+                  >
+                    {approveMutation.isPending ? (
+                      <>
+                        <span className="animate-spin mr-2">⏳</span>
+                        Approving...
+                      </>
+                    ) : (
+                      <>
+                        <CheckCircle className="w-4 h-4 mr-2" />
+                        Approve
+                      </>
+                    )}
+                  </Button>
+                  <Button
+                    onClick={() => setPendingAction('reject')}
+                    disabled={isLoading}
+                    variant="destructive"
+                    className="flex-1"
+                  >
+                    <XCircle className="w-4 h-4 mr-2" />
+                    Reject
+                  </Button>
+                </>
+              )}
+              {application.verification_status === 'verified' && (
+                <Button
+                  onClick={() => setPendingAction('revoke')}
+                  disabled={isLoading}
+                  variant="destructive"
+                  className="flex-1"
+                >
+                  <Ban className="w-4 h-4 mr-2" />
+                  Revoke Verification
+                </Button>
+              )}
+              {(application.verification_status === 'rejected' ||
+                application.verification_status === 'revoked') && (
                 <Button
                   onClick={handleApprove}
                   disabled={isLoading}
@@ -322,52 +389,11 @@ export function MerchantApplicationModal({
                     </>
                   )}
                 </Button>
-                <Button
-                  onClick={() => setPendingAction('reject')}
-                  disabled={isLoading}
-                  variant="destructive"
-                  className="flex-1"
-                >
-                  <XCircle className="w-4 h-4 mr-2" />
-                  Reject
-                </Button>
-              </>
-            )}
-            {application.verification_status === 'verified' && (
-              <Button
-                onClick={() => setPendingAction('revoke')}
-                disabled={isLoading}
-                variant="destructive"
-                className="flex-1"
-              >
-                <Ban className="w-4 h-4 mr-2" />
-                Revoke Verification
-              </Button>
-            )}
-            {(application.verification_status === 'rejected' ||
-              application.verification_status === 'revoked') && (
-              <Button
-                onClick={handleApprove}
-                disabled={isLoading}
-                className="btn-emerald flex-1"
-              >
-                {approveMutation.isPending ? (
-                    <>
-                      <span className="animate-spin mr-2">⏳</span>
-                      Approving...
-                    </>
-                  ) : (
-                    <>
-                      <CheckCircle className="w-4 h-4 mr-2" />
-                      Approve
-                    </>
-                  )}
-              </Button>
-            )}
+              )}
+            </div>
           </div>
-        </div>
-      </DialogContent>
-    </Dialog>
+        </DialogContent>
+      </Dialog>
     </>
   );
 }

--- a/apps/web/components/admin/MerchantApplications.tsx
+++ b/apps/web/components/admin/MerchantApplications.tsx
@@ -1,7 +1,8 @@
 'use client';
 
+import { CheckCircle, Eye, Loader2, XCircle } from 'lucide-react';
 import { useState } from 'react';
-import { Loader2, CheckCircle, XCircle, Eye } from 'lucide-react';
+import { toast } from 'sonner';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
@@ -12,17 +13,16 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
-import { Textarea } from '@/components/ui/textarea';
 import { Label } from '@/components/ui/label';
-import { MerchantApplicationModal } from './MerchantApplicationModal';
-import { MerchantApplicationFilters } from './MerchantApplicationFilters';
+import { Textarea } from '@/components/ui/textarea';
 import {
-  useMerchantApplications,
   useApproveMerchant,
+  useMerchantApplications,
   useRejectMerchant,
 } from '@/hooks/use-admin';
-import { toast } from 'sonner';
 import type { MerchantApplication } from '@/lib/types/admin';
+import { MerchantApplicationFilters } from './MerchantApplicationFilters';
+import { MerchantApplicationModal } from './MerchantApplicationModal';
 
 const statusVariants: Record<
   MerchantApplication['verification_status'],
@@ -42,7 +42,9 @@ export function MerchantApplications() {
   const [activeFilter, setActiveFilter] = useState('pending');
   const [selectedApplication, setSelectedApplication] =
     useState<MerchantApplication | null>(null);
-  const [rejectTarget, setRejectTarget] = useState<MerchantApplication | null>(null);
+  const [rejectTarget, setRejectTarget] = useState<MerchantApplication | null>(
+    null
+  );
   const [rejectMessage, setRejectMessage] = useState('');
 
   const {
@@ -67,7 +69,10 @@ export function MerchantApplications() {
   const handleConfirmReject = async () => {
     if (!rejectTarget || !rejectMessage.trim()) return;
     try {
-      await rejectMutation.mutateAsync({ id: rejectTarget.id, reason: rejectMessage.trim() });
+      await rejectMutation.mutateAsync({
+        id: rejectTarget.id,
+        reason: rejectMessage.trim(),
+      });
       toast.success('Merchant application rejected');
       setRejectTarget(null);
       setRejectMessage('');
@@ -213,7 +218,12 @@ export function MerchantApplications() {
 
       <Dialog
         open={rejectTarget !== null}
-        onOpenChange={(open) => { if (!open) { setRejectTarget(null); setRejectMessage(''); } }}
+        onOpenChange={(open) => {
+          if (!open) {
+            setRejectTarget(null);
+            setRejectMessage('');
+          }
+        }}
       >
         <DialogContent className="max-w-md">
           <DialogHeader>
@@ -237,7 +247,10 @@ export function MerchantApplications() {
           <DialogFooter>
             <Button
               variant="ghost"
-              onClick={() => { setRejectTarget(null); setRejectMessage(''); }}
+              onClick={() => {
+                setRejectTarget(null);
+                setRejectMessage('');
+              }}
               disabled={rejectMutation.isPending}
             >
               Cancel

--- a/apps/web/components/admin/audit-log-viewer.tsx
+++ b/apps/web/components/admin/audit-log-viewer.tsx
@@ -19,7 +19,7 @@ export function AuditLogViewer({ className }: AuditLogViewerProps) {
   const { data, isLoading, error } = useAuditLogs(filters);
 
   const formatAction = (action: string) => {
-    return action.replace('_', ' ').replace(/\b\w/g, l => l.toUpperCase());
+    return action.replace('_', ' ').replace(/\b\w/g, (l) => l.toUpperCase());
   };
 
   const formatDate = (dateString: string) => {
@@ -27,11 +27,11 @@ export function AuditLogViewer({ className }: AuditLogViewerProps) {
   };
 
   const handleFilterChange = (key: string, value: string) => {
-    setFilters(prev => ({ ...prev, [key]: value, offset: 0 }));
+    setFilters((prev) => ({ ...prev, [key]: value, offset: 0 }));
   };
 
   const handlePageChange = (newOffset: number) => {
-    setFilters(prev => ({ ...prev, offset: newOffset }));
+    setFilters((prev) => ({ ...prev, offset: newOffset }));
   };
 
   if (error) {
@@ -46,7 +46,7 @@ export function AuditLogViewer({ className }: AuditLogViewerProps) {
     <div className={`space-y-4 ${className}`}>
       <div className="flex gap-4 items-center">
         <h2 className="text-xl font-semibold">Admin Audit Log</h2>
-        
+
         <select
           value={filters.action}
           onChange={(e) => handleFilterChange('action', e.target.value)}
@@ -80,11 +80,21 @@ export function AuditLogViewer({ className }: AuditLogViewerProps) {
             <table className="w-full border-collapse border border-gray-300">
               <thead>
                 <tr className="bg-gray-50">
-                  <th className="border border-gray-300 px-4 py-2 text-left">Date</th>
-                  <th className="border border-gray-300 px-4 py-2 text-left">Admin</th>
-                  <th className="border border-gray-300 px-4 py-2 text-left">Action</th>
-                  <th className="border border-gray-300 px-4 py-2 text-left">Target</th>
-                  <th className="border border-gray-300 px-4 py-2 text-left">Details</th>
+                  <th className="border border-gray-300 px-4 py-2 text-left">
+                    Date
+                  </th>
+                  <th className="border border-gray-300 px-4 py-2 text-left">
+                    Admin
+                  </th>
+                  <th className="border border-gray-300 px-4 py-2 text-left">
+                    Action
+                  </th>
+                  <th className="border border-gray-300 px-4 py-2 text-left">
+                    Target
+                  </th>
+                  <th className="border border-gray-300 px-4 py-2 text-left">
+                    Details
+                  </th>
                 </tr>
               </thead>
               <tbody>
@@ -94,7 +104,9 @@ export function AuditLogViewer({ className }: AuditLogViewerProps) {
                       {formatDate(log.performed_at)}
                     </td>
                     <td className="border border-gray-300 px-4 py-2 text-sm">
-                      {log.admin_user?.full_name || log.admin_user?.email || 'Unknown'}
+                      {log.admin_user?.full_name ||
+                        log.admin_user?.email ||
+                        'Unknown'}
                     </td>
                     <td className="border border-gray-300 px-4 py-2 text-sm">
                       <span className="px-2 py-1 bg-blue-100 text-blue-800 rounded text-xs">
@@ -111,16 +123,25 @@ export function AuditLogViewer({ className }: AuditLogViewerProps) {
                     </td>
                     <td className="border border-gray-300 px-4 py-2 text-sm">
                       {!!log.metadata.reason && (
-                        <div><strong>Reason:</strong> {String(log.metadata.reason)}</div>
+                        <div>
+                          <strong>Reason:</strong> {String(log.metadata.reason)}
+                        </div>
                       )}
                       {!!log.metadata.amount && (
-                        <div><strong>Amount:</strong> {String(log.metadata.amount)}</div>
+                        <div>
+                          <strong>Amount:</strong> {String(log.metadata.amount)}
+                        </div>
                       )}
                       {!!log.metadata.token && (
-                        <div><strong>Token:</strong> {String(log.metadata.token)}</div>
+                        <div>
+                          <strong>Token:</strong> {String(log.metadata.token)}
+                        </div>
                       )}
                       {!!log.metadata.display_name && (
-                        <div><strong>Merchant:</strong> {String(log.metadata.display_name)}</div>
+                        <div>
+                          <strong>Merchant:</strong>{' '}
+                          {String(log.metadata.display_name)}
+                        </div>
                       )}
                     </td>
                   </tr>
@@ -132,18 +153,28 @@ export function AuditLogViewer({ className }: AuditLogViewerProps) {
           {data?.total > filters.limit && (
             <div className="flex justify-between items-center">
               <div className="text-sm text-gray-600">
-                Showing {filters.offset + 1} to {Math.min(filters.offset + filters.limit, data.total)} of {data.total} entries
+                Showing {filters.offset + 1} to{' '}
+                {Math.min(filters.offset + filters.limit, data.total)} of{' '}
+                {data.total} entries
               </div>
               <div className="flex gap-2">
                 <button
-                  onClick={() => handlePageChange(Math.max(0, filters.offset - filters.limit))}
+                  type="button"
+                  onClick={() =>
+                    handlePageChange(
+                      Math.max(0, filters.offset - filters.limit)
+                    )
+                  }
                   disabled={filters.offset === 0}
                   className="px-3 py-1 border rounded disabled:opacity-50"
                 >
                   Previous
                 </button>
                 <button
-                  onClick={() => handlePageChange(filters.offset + filters.limit)}
+                  type="button"
+                  onClick={() =>
+                    handlePageChange(filters.offset + filters.limit)
+                  }
                   disabled={filters.offset + filters.limit >= data.total}
                   className="px-3 py-1 border rounded disabled:opacity-50"
                 >

--- a/apps/web/components/auth-guard.tsx
+++ b/apps/web/components/auth-guard.tsx
@@ -2,8 +2,8 @@
 
 import { usePathname } from 'next/navigation';
 import { useEffect, useRef, useState } from 'react';
-import useGlobalAuthenticationStore from '@/store/wallet.store';
 import { supabase } from '@/lib/supabase';
+import useGlobalAuthenticationStore from '@/store/wallet.store';
 
 interface AuthGuardProps {
   children: React.ReactNode;

--- a/apps/web/components/chat/ChatInput.tsx
+++ b/apps/web/components/chat/ChatInput.tsx
@@ -1,13 +1,13 @@
 'use client';
 
+import { Paperclip, Send, X } from 'lucide-react';
 import {
+  type ChangeEvent,
+  type KeyboardEvent,
   useCallback,
   useRef,
   useState,
-  type KeyboardEvent,
-  type ChangeEvent,
 } from 'react';
-import { Paperclip, Send, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 
@@ -97,7 +97,9 @@ export function ChatInput({
               className="h-12 w-12 object-cover rounded"
             />
           ) : (
-            <span className="text-muted-foreground">📎 {preview.file.name}</span>
+            <span className="text-muted-foreground">
+              📎 {preview.file.name}
+            </span>
           )}
           <button
             type="button"

--- a/apps/web/components/chat/OnlineStatusDot.tsx
+++ b/apps/web/components/chat/OnlineStatusDot.tsx
@@ -20,7 +20,11 @@ function formatLastSeen(date: Date): string {
   return 'Active recently';
 }
 
-export function OnlineStatusDot({ online, lastSeen, className }: OnlineStatusDotProps) {
+export function OnlineStatusDot({
+  online,
+  lastSeen,
+  className,
+}: OnlineStatusDotProps) {
   // Re-render every minute so the relative time stays fresh
   const [, setTick] = useState(0);
   useEffect(() => {
@@ -32,8 +36,8 @@ export function OnlineStatusDot({ online, lastSeen, className }: OnlineStatusDot
   const label = online
     ? 'Online'
     : lastSeen
-    ? formatLastSeen(lastSeen)
-    : 'Offline';
+      ? formatLastSeen(lastSeen)
+      : 'Offline';
 
   return (
     <span className={cn('flex items-center gap-1 text-xs', className)}>

--- a/apps/web/components/chat/TradeChatPanel.tsx
+++ b/apps/web/components/chat/TradeChatPanel.tsx
@@ -1,24 +1,40 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
 import { ChevronDown } from 'lucide-react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { Button } from '@/components/ui/button';
-import { useTradeChat, useSendMessage, useTypingIndicator, useMarkAsRead } from '@/hooks/use-chat';
-import { ChatMessage } from './ChatMessage';
+import {
+  useMarkAsRead,
+  useSendMessage,
+  useTradeChat,
+  useTypingIndicator,
+} from '@/hooks/use-chat';
 import { ChatInput } from './ChatInput';
-import { TypingIndicator } from './TypingIndicator';
+import { ChatMessage } from './ChatMessage';
 import { OnlineStatusDot } from './OnlineStatusDot';
+import { TypingIndicator } from './TypingIndicator';
 
 interface TradeChatPanelProps {
   engagementId: string;
   currentUserId: string;
 }
 
-export function TradeChatPanel({ engagementId, currentUserId }: TradeChatPanelProps) {
-  const { chat, messages, isLoading, otherPartyOnline, otherPartyLastSeen, otherPartyTyping } =
-    useTradeChat(engagementId);
+export function TradeChatPanel({
+  engagementId,
+  currentUserId,
+}: TradeChatPanelProps) {
+  const {
+    chat,
+    messages,
+    isLoading,
+    otherPartyOnline,
+    otherPartyLastSeen,
+    otherPartyTyping,
+  } = useTradeChat(engagementId);
 
-  const { sendText, sendAttachment, isSending } = useSendMessage(chat?.id ?? null);
+  const { sendText, sendAttachment, isSending } = useSendMessage(
+    chat?.id ?? null
+  );
   const { setTyping } = useTypingIndicator(chat?.id ?? null);
   const { markRead } = useMarkAsRead(chat?.id ?? null);
 
@@ -59,7 +75,10 @@ export function TradeChatPanel({ engagementId, currentUserId }: TradeChatPanelPr
       {/* Header */}
       <div className="flex items-center justify-between px-4 py-3 border-b border-border/50 bg-muted/30 shrink-0">
         <span className="text-sm font-medium text-foreground">Trade Chat</span>
-        <OnlineStatusDot online={otherPartyOnline} lastSeen={otherPartyLastSeen} />
+        <OnlineStatusDot
+          online={otherPartyOnline}
+          lastSeen={otherPartyLastSeen}
+        />
       </div>
 
       {/* Message list */}
@@ -70,7 +89,9 @@ export function TradeChatPanel({ engagementId, currentUserId }: TradeChatPanelPr
       >
         {isLoading && (
           <div className="flex justify-center py-8">
-            <span className="text-sm text-muted-foreground">Loading messages…</span>
+            <span className="text-sm text-muted-foreground">
+              Loading messages…
+            </span>
           </div>
         )}
 

--- a/apps/web/components/escrow/EmptyState.tsx
+++ b/apps/web/components/escrow/EmptyState.tsx
@@ -1,7 +1,7 @@
 'use client';
 
+import { ArrowUpRight, ShieldOff } from 'lucide-react';
 import Link from 'next/link';
-import { ShieldOff, ArrowUpRight } from 'lucide-react';
 
 export function EmptyState() {
   return (
@@ -10,7 +10,9 @@ export function EmptyState() {
         <ShieldOff className="w-6 h-6 text-muted-foreground/50" />
       </div>
       <div>
-        <h3 className="text-sm font-semibold text-white mb-1">No orders found</h3>
+        <h3 className="text-sm font-semibold text-white mb-1">
+          No orders found
+        </h3>
         <p className="text-xs text-muted-foreground/60">
           You don&apos;t have any active escrow contracts yet.
         </p>

--- a/apps/web/components/escrow/EscrowCard.tsx
+++ b/apps/web/components/escrow/EscrowCard.tsx
@@ -1,17 +1,22 @@
 'use client';
 
-import { ExternalLink, MessageCircle, ArrowDownLeft, ArrowUpRight } from 'lucide-react';
+import {
+  ArrowDownLeft,
+  ArrowUpRight,
+  ExternalLink,
+  MessageCircle,
+} from 'lucide-react';
+import { UnreadBadge } from '@/components/chat/UnreadBadge';
 import { Button } from '@/components/ui/button';
 import { formatAmount } from '@/lib/dashboard-utils';
-import { getTrustlineName } from '@/utils/getTrustline';
-import type { Escrow } from '@/lib/types/escrow';
-import { UnreadBadge } from '@/components/chat/UnreadBadge';
 import {
-  canReportPayment,
   canConfirmPayment,
   canDeposit,
   canReleaseFunds,
+  canReportPayment,
 } from '@/lib/escrow-utils';
+import type { Escrow } from '@/lib/types/escrow';
+import { getTrustlineName } from '@/utils/getTrustline';
 
 interface EscrowCardProps {
   escrow: Escrow;
@@ -20,31 +25,45 @@ interface EscrowCardProps {
   role?: 'buyer' | 'seller';
 }
 
-export function EscrowCard({ escrow, onClick, unreadCount = 0, role = 'buyer' }: EscrowCardProps) {
+export function EscrowCard({
+  escrow,
+  onClick,
+  unreadCount = 0,
+  role = 'buyer',
+}: EscrowCardProps) {
   const isCompleted = escrow.flags?.resolved || escrow.flags?.released;
   const isDisputed = escrow.flags?.disputed;
   const token = getTrustlineName(escrow.trustline.address);
   const userRole = role;
 
-  const statusLabel = isCompleted ? 'Completed' : isDisputed ? 'Disputed' : 'In Progress';
+  const statusLabel = isCompleted
+    ? 'Completed'
+    : isDisputed
+      ? 'Disputed'
+      : 'In Progress';
   const statusStyles = isCompleted
     ? 'bg-emerald-500/10 text-emerald-400 border-emerald-500/20'
     : isDisputed
-    ? 'bg-red-500/10 text-red-400 border-red-500/20'
-    : 'bg-yellow-500/10 text-yellow-400 border-yellow-500/20';
+      ? 'bg-red-500/10 text-red-400 border-red-500/20'
+      : 'bg-yellow-500/10 text-yellow-400 border-yellow-500/20';
 
   // Determine what action is needed
   const getActionNeeded = () => {
-    if (canDeposit(escrow, userRole)) return { label: 'Deposit needed', color: 'text-orange-400' };
-    if (canReportPayment(escrow, userRole)) return { label: 'Awaiting your payment', color: 'text-blue-400' };
-    if (canConfirmPayment(escrow, userRole)) return { label: 'Confirm payment received', color: 'text-blue-400' };
-    if (canReleaseFunds(escrow, userRole)) return { label: 'Ready to release', color: 'text-emerald-400' };
+    if (canDeposit(escrow, userRole))
+      return { label: 'Deposit needed', color: 'text-orange-400' };
+    if (canReportPayment(escrow, userRole))
+      return { label: 'Awaiting your payment', color: 'text-blue-400' };
+    if (canConfirmPayment(escrow, userRole))
+      return { label: 'Confirm payment received', color: 'text-blue-400' };
+    if (canReleaseFunds(escrow, userRole))
+      return { label: 'Ready to release', color: 'text-emerald-400' };
     return null;
   };
   const actionNeeded = getActionNeeded();
 
   const counterpartyLabel = role === 'buyer' ? 'Seller' : 'Buyer';
-  const counterpartyAddress = role === 'buyer' ? escrow.roles.approver : escrow.roles.serviceProvider;
+  const counterpartyAddress =
+    role === 'buyer' ? escrow.roles.approver : escrow.roles.serviceProvider;
 
   return (
     <div
@@ -55,11 +74,14 @@ export function EscrowCard({ escrow, onClick, unreadCount = 0, role = 'buyer' }:
       <div className="flex items-start justify-between gap-4">
         <div className="flex items-start gap-3 min-w-0">
           {/* Direction icon */}
-          <div className={`mt-1 w-8 h-8 rounded-lg flex items-center justify-center shrink-0 ${role === 'buyer' ? 'bg-blue-500/10 text-blue-400' : 'bg-emerald-500/10 text-emerald-400'}`}>
-            {role === 'buyer'
-              ? <ArrowDownLeft className="w-4 h-4" />
-              : <ArrowUpRight className="w-4 h-4" />
-            }
+          <div
+            className={`mt-1 w-8 h-8 rounded-lg flex items-center justify-center shrink-0 ${role === 'buyer' ? 'bg-blue-500/10 text-blue-400' : 'bg-emerald-500/10 text-emerald-400'}`}
+          >
+            {role === 'buyer' ? (
+              <ArrowDownLeft className="w-4 h-4" />
+            ) : (
+              <ArrowUpRight className="w-4 h-4" />
+            )}
           </div>
           <div className="min-w-0">
             <div className="flex items-center gap-2 flex-wrap">
@@ -87,7 +109,9 @@ export function EscrowCard({ escrow, onClick, unreadCount = 0, role = 'buyer' }:
         </div>
 
         {/* Status pill */}
-        <span className={`text-xs font-semibold px-2.5 py-1 rounded-full border shrink-0 ${statusStyles}`}>
+        <span
+          className={`text-xs font-semibold px-2.5 py-1 rounded-full border shrink-0 ${statusStyles}`}
+        >
           {statusLabel}
         </span>
       </div>
@@ -95,7 +119,9 @@ export function EscrowCard({ escrow, onClick, unreadCount = 0, role = 'buyer' }:
       {/* Info row */}
       <div className="mt-4 grid grid-cols-3 gap-3">
         <div className="bg-white/[0.04] rounded-lg px-3 py-2">
-          <p className="text-xs text-muted-foreground mb-0.5">{counterpartyLabel}</p>
+          <p className="text-xs text-muted-foreground mb-0.5">
+            {counterpartyLabel}
+          </p>
           <p className="font-mono text-xs text-foreground">
             {counterpartyAddress.slice(0, 6)}…{counterpartyAddress.slice(-6)}
           </p>
@@ -124,7 +150,10 @@ export function EscrowCard({ escrow, onClick, unreadCount = 0, role = 'buyer' }:
             className="text-muted-foreground hover:text-emerald-400 shrink-0 px-2 h-7"
             onClick={(e) => {
               e.stopPropagation();
-              window.open(`https://viewer.trustlesswork.com/${escrow.contractId}`, '_blank');
+              window.open(
+                `https://viewer.trustlesswork.com/${escrow.contractId}`,
+                '_blank'
+              );
             }}
           >
             <ExternalLink className="w-3.5 h-3.5 mr-1" />

--- a/apps/web/components/escrow/EscrowDetailsModal.tsx
+++ b/apps/web/components/escrow/EscrowDetailsModal.tsx
@@ -10,6 +10,8 @@ import {
   XCircle,
 } from 'lucide-react';
 import { useEffect, useState } from 'react';
+import { TradeChatPanel } from '@/components/chat/TradeChatPanel';
+import { TrustlineBanner } from '@/components/shared/TrustlineBanner';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,
@@ -18,14 +20,8 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { useAuth } from '@/hooks/use-auth';
 import { formatAmount } from '@/lib/dashboard-utils';
-import type { EscrowTransactionHashes } from '@/lib/services/trades';
-import { TradesService } from '@/lib/services/trades';
-import { getTrustlineName } from '@/utils/getTrustline';
-import { Escrow } from '@/lib/types/escrow';
-import { EscrowTransactionHashesDisplay } from './TransactionHashDisplay';
-import { TrustlineError } from '@/utils/stellar/TrustlineError';
-import { TrustlineBanner } from '@/components/shared/TrustlineBanner';
 import {
   canCancel,
   canConfirmPayment,
@@ -36,8 +32,12 @@ import {
   getEscrowCancellationGraceHours,
   getEscrowCreatedAt,
 } from '@/lib/escrow-utils';
-import { TradeChatPanel } from '@/components/chat/TradeChatPanel';
-import { useAuth } from '@/hooks/use-auth';
+import type { EscrowTransactionHashes } from '@/lib/services/trades';
+import { TradesService } from '@/lib/services/trades';
+import type { Escrow } from '@/lib/types/escrow';
+import { getTrustlineName } from '@/utils/getTrustline';
+import { TrustlineError } from '@/utils/stellar/TrustlineError';
+import { EscrowTransactionHashesDisplay } from './TransactionHashDisplay';
 
 interface EscrowDetailsModalProps {
   open: boolean;
@@ -71,7 +71,9 @@ export function EscrowDetailsModal({
   const { user } = useAuth();
   const [transactionHashes, setTransactionHashes] =
     useState<EscrowTransactionHashes | null>(null);
-  const [trustlineError, setTrustlineError] = useState<TrustlineError | null>(null);
+  const [trustlineError, setTrustlineError] = useState<TrustlineError | null>(
+    null
+  );
 
   useEffect(() => {
     if (open && escrow?.engagementId) {
@@ -130,7 +132,6 @@ export function EscrowDetailsModal({
 
           {/* ── DETAILS TAB ── */}
           <TabsContent value="details" className="space-y-5">
-
             {/* Amount + status hero */}
             <div className="flex items-center justify-between bg-muted/40 rounded-lg px-5 py-4">
               <div>
@@ -152,7 +153,9 @@ export function EscrowDetailsModal({
             {/* Description */}
             {escrow.description && (
               <div>
-                <p className="text-xs text-muted-foreground mb-1">Description</p>
+                <p className="text-xs text-muted-foreground mb-1">
+                  Description
+                </p>
                 <p className="text-sm text-foreground bg-muted/30 rounded-md px-3 py-2">
                   {escrow.description}
                 </p>
@@ -162,13 +165,17 @@ export function EscrowDetailsModal({
             {/* Parties */}
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
               <div className="bg-muted/40 rounded-md px-3 py-2.5">
-                <p className="text-xs text-muted-foreground mb-1">Seller (releases crypto)</p>
+                <p className="text-xs text-muted-foreground mb-1">
+                  Seller (releases crypto)
+                </p>
                 <p className="font-mono text-xs text-foreground break-all">
                   {escrow.roles.approver}
                 </p>
               </div>
               <div className="bg-muted/40 rounded-md px-3 py-2.5">
-                <p className="text-xs text-muted-foreground mb-1">Buyer (pays fiat)</p>
+                <p className="text-xs text-muted-foreground mb-1">
+                  Buyer (pays fiat)
+                </p>
                 <p className="font-mono text-xs text-foreground break-all">
                   {escrow.roles.serviceProvider}
                 </p>
@@ -177,7 +184,9 @@ export function EscrowDetailsModal({
 
             {/* Engagement ID */}
             <div>
-              <p className="text-xs text-muted-foreground mb-1">Engagement ID</p>
+              <p className="text-xs text-muted-foreground mb-1">
+                Engagement ID
+              </p>
               <p className="font-mono text-xs text-foreground bg-muted/30 rounded-md px-3 py-2 break-all">
                 {escrow.engagementId}
               </p>
@@ -194,22 +203,21 @@ export function EscrowDetailsModal({
 
             {/* Actions */}
             <div className="flex flex-wrap gap-2 pt-2 border-t border-border/50">
-              {activeTab === 'buyer' &&
-                canReportPayment(escrow, userRole) && (
-                  <Button
-                    onClick={() => onReportPayment(escrow)}
-                    className="btn-emerald-outline flex-1"
-                    variant="outline"
-                    disabled={isReportPaymentLoading}
-                  >
-                    {isReportPaymentLoading ? (
-                      <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-                    ) : (
-                      <Banknote className="w-4 h-4 mr-2" />
-                    )}
-                    I&apos;ve Sent Payment
-                  </Button>
-                )}
+              {activeTab === 'buyer' && canReportPayment(escrow, userRole) && (
+                <Button
+                  onClick={() => onReportPayment(escrow)}
+                  className="btn-emerald-outline flex-1"
+                  variant="outline"
+                  disabled={isReportPaymentLoading}
+                >
+                  {isReportPaymentLoading ? (
+                    <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                  ) : (
+                    <Banknote className="w-4 h-4 mr-2" />
+                  )}
+                  I&apos;ve Sent Payment
+                </Button>
+              )}
 
               {activeTab === 'seller' && (
                 <>
@@ -251,7 +259,8 @@ export function EscrowDetailsModal({
                         try {
                           await onReleaseFunds(escrow);
                         } catch (err) {
-                          if (err instanceof TrustlineError) setTrustlineError(err);
+                          if (err instanceof TrustlineError)
+                            setTrustlineError(err);
                         }
                       }}
                       className="btn-emerald-outline flex-1"

--- a/apps/web/components/escrow/ReportPaymentModal.tsx
+++ b/apps/web/components/escrow/ReportPaymentModal.tsx
@@ -20,7 +20,7 @@ import {
   FormMessage,
 } from '@/components/ui/form';
 import { Textarea } from '@/components/ui/textarea';
-import { ReportPaymentData } from '@/lib/types/escrow';
+import type { ReportPaymentData } from '@/lib/types/escrow';
 
 interface ReportPaymentModalProps {
   open: boolean;

--- a/apps/web/components/escrow/TransactionHashDisplay.tsx
+++ b/apps/web/components/escrow/TransactionHashDisplay.tsx
@@ -21,7 +21,9 @@ export function TransactionHashLink({
 
   return (
     <div className="flex items-center gap-2">
-      <span className="text-sm text-muted-foreground min-w-[80px]">{label}:</span>
+      <span className="text-sm text-muted-foreground min-w-[80px]">
+        {label}:
+      </span>
       <a
         href={explorerUrl}
         target="_blank"
@@ -61,9 +63,7 @@ export function EscrowTransactionHashesDisplay({
     { key: 'dispute' as const, label: 'Dispute' },
   ];
 
-  const hasAnyHash = actions.some(
-    (action) => transactionHashes[action.key]
-  );
+  const hasAnyHash = actions.some((action) => transactionHashes[action.key]);
 
   if (!hasAnyHash) return null;
 

--- a/apps/web/components/escrow/index.ts
+++ b/apps/web/components/escrow/index.ts
@@ -1,6 +1,6 @@
+export { EmptyState } from './EmptyState';
+export { ErrorState } from './ErrorState';
 export { EscrowCard } from './EscrowCard';
 export { EscrowDetailsModal } from './EscrowDetailsModal';
-export { ReportPaymentModal } from './ReportPaymentModal';
-export { EmptyState } from './EmptyState';
 export { LoadingState } from './LoadingState';
-export { ErrorState } from './ErrorState';
+export { ReportPaymentModal } from './ReportPaymentModal';

--- a/apps/web/components/landing/HeroSection.tsx
+++ b/apps/web/components/landing/HeroSection.tsx
@@ -3,11 +3,10 @@
 import { motion, useReducedMotion } from 'framer-motion';
 import { ArrowRight } from 'lucide-react';
 import Link from 'next/link';
-
-import WaitlistDialog from '@/components/marketing/WaitlistDialog';
-import { Button } from '@/components/ui/button';
-import RotatingText from '@/components/RotatingText';
 import { MacbookScrollDemo } from '@/components/landing/MacbookScrollDemo';
+import WaitlistDialog from '@/components/marketing/WaitlistDialog';
+import RotatingText from '@/components/RotatingText';
+import { Button } from '@/components/ui/button';
 
 export function HeroSection() {
   const reducedMotion = useReducedMotion();

--- a/apps/web/components/layout/app-sidebar.tsx
+++ b/apps/web/components/layout/app-sidebar.tsx
@@ -1,20 +1,20 @@
 'use client';
 
-import Image from 'next/image';
-import Link from 'next/link';
-import { usePathname } from 'next/navigation';
 import {
   Home,
   List,
-  Users,
+  LogIn,
+  LogOut,
+  Settings,
   Shield,
   User,
-  Settings,
+  Users,
   Wallet,
-  LogOut,
-  LogIn,
 } from 'lucide-react';
-
+import Image from 'next/image';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { sileo } from 'sileo';
 import { Button } from '@/components/ui/button';
 import {
   Sidebar,
@@ -35,12 +35,11 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '@/components/ui/tooltip';
-import { useWallet } from '@/hooks/use-wallet';
 import { useAuth } from '@/hooks/use-auth';
+import { useWallet } from '@/hooks/use-wallet';
+import { useMerchantStatus } from '@/hooks/useMerchant';
 import { cn } from '@/lib/utils';
 import useGlobalAuthenticationStore from '@/store/wallet.store';
-import { sileo } from 'sileo';
-import { useMerchantStatus } from '@/hooks/useMerchant';
 
 const navigation = [
   { name: 'Dashboard', href: '/dashboard', icon: Home },
@@ -87,9 +86,11 @@ export function AppSidebar() {
       const connectedAddress = await handleConnect();
       if (connectedAddress) {
         if (user) {
-          await updateProfile({ stellar_address: connectedAddress }).catch(() => {
-            // Ignore DB linking errors (e.g. address already saved on another account)
-          });
+          await updateProfile({ stellar_address: connectedAddress }).catch(
+            () => {
+              // Ignore DB linking errors (e.g. address already saved on another account)
+            }
+          );
         }
         sileo.success({ title: 'Wallet connected successfully' });
       }

--- a/apps/web/components/layout/dashboard-header.tsx
+++ b/apps/web/components/layout/dashboard-header.tsx
@@ -1,27 +1,26 @@
 'use client';
 
+import {
+  ChevronDown,
+  Copy,
+  Home,
+  List,
+  LogIn,
+  LogOut,
+  Menu,
+  Settings,
+  Shield,
+  Unplug,
+  User,
+  Users,
+  X,
+} from 'lucide-react';
 import Image from 'next/image';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import {
-  Home,
-  List,
-  Users,
-  Shield,
-  User,
-  Settings,
-  LogOut,
-  LogIn,
-  Menu,
-  X,
-  ChevronDown,
-  Copy,
-  Unplug,
-} from 'lucide-react';
-import { useState, useEffect } from 'react';
-
+import { useEffect, useState } from 'react';
+import { sileo } from 'sileo';
 import { Button } from '@/components/ui/button';
-import { usePendingActions } from '@/hooks/use-pending-actions';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -31,11 +30,11 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet';
-import { useWallet } from '@/hooks/use-wallet';
 import { useAuth } from '@/hooks/use-auth';
+import { usePendingActions } from '@/hooks/use-pending-actions';
+import { useWallet } from '@/hooks/use-wallet';
 import { cn } from '@/lib/utils';
 import useGlobalAuthenticationStore from '@/store/wallet.store';
-import { sileo } from 'sileo';
 
 const navigation = [
   { name: 'Dashboard', href: '/dashboard', icon: Home },
@@ -110,9 +109,11 @@ export function DashboardHeader() {
       const connectedAddress = await handleConnect();
       if (connectedAddress) {
         if (user) {
-          await updateProfile({ stellar_address: connectedAddress }).catch(() => {
-            // Ignore DB linking errors (e.g. address already saved on another account)
-          });
+          await updateProfile({ stellar_address: connectedAddress }).catch(
+            () => {
+              // Ignore DB linking errors (e.g. address already saved on another account)
+            }
+          );
         }
         sileo.success({ title: 'Wallet connected successfully' });
       }
@@ -143,9 +144,11 @@ export function DashboardHeader() {
       const connectedAddress = await handleConnect();
       if (connectedAddress) {
         if (user) {
-          await updateProfile({ stellar_address: connectedAddress }).catch(() => {
-            // Ignore DB linking errors (e.g. address already saved on another account)
-          });
+          await updateProfile({ stellar_address: connectedAddress }).catch(
+            () => {
+              // Ignore DB linking errors (e.g. address already saved on another account)
+            }
+          );
         }
         sileo.success({ title: 'Wallet connected successfully' });
       }
@@ -227,7 +230,11 @@ export function DashboardHeader() {
               <NavLink
                 key={item.name}
                 item={item}
-                badge={item.href === '/dashboard/orders' && pendingCount > 0 ? pendingCount : undefined}
+                badge={
+                  item.href === '/dashboard/orders' && pendingCount > 0
+                    ? pendingCount
+                    : undefined
+                }
               />
             ))}
             {canSeeAdmin && (
@@ -305,9 +312,13 @@ export function DashboardHeader() {
                   {/* User info */}
                   <DropdownMenuLabel>
                     <div className="flex flex-col space-y-0.5">
-                      <p className="text-sm font-semibold">{getUserDisplayName()}</p>
+                      <p className="text-sm font-semibold">
+                        {getUserDisplayName()}
+                      </p>
                       {user?.email && (
-                        <p className="text-xs text-muted-foreground">{user.email}</p>
+                        <p className="text-xs text-muted-foreground">
+                          {user.email}
+                        </p>
                       )}
                     </div>
                   </DropdownMenuLabel>
@@ -318,15 +329,21 @@ export function DashboardHeader() {
                       <DropdownMenuSeparator />
                       <DropdownMenuLabel>
                         <div className="flex flex-col space-y-0.5">
-                          <p className="text-xs text-muted-foreground">Connected wallet</p>
-                          <p className="text-xs font-mono text-emerald-400 truncate">{address}</p>
+                          <p className="text-xs text-muted-foreground">
+                            Connected wallet
+                          </p>
+                          <p className="text-xs font-mono text-emerald-400 truncate">
+                            {address}
+                          </p>
                         </div>
                       </DropdownMenuLabel>
                       <DropdownMenuItem
                         className="cursor-pointer"
                         onClick={() => {
                           navigator.clipboard.writeText(address);
-                          sileo.success({ title: 'Address copied to clipboard' });
+                          sileo.success({
+                            title: 'Address copied to clipboard',
+                          });
                         }}
                       >
                         <Copy className="w-4 h-4 mr-2" />
@@ -343,7 +360,10 @@ export function DashboardHeader() {
                   ) : (
                     <>
                       <DropdownMenuSeparator />
-                      <DropdownMenuItem onClick={handleWalletConnect} className="cursor-pointer">
+                      <DropdownMenuItem
+                        onClick={handleWalletConnect}
+                        className="cursor-pointer"
+                      >
                         <LogIn className="w-4 h-4 mr-2" />
                         Connect Wallet
                       </DropdownMenuItem>
@@ -436,7 +456,11 @@ export function DashboardHeader() {
                         key={item.name}
                         item={item}
                         onClick={() => setMobileMenuOpen(false)}
-                        badge={item.href === '/dashboard/orders' && pendingCount > 0 ? pendingCount : undefined}
+                        badge={
+                          item.href === '/dashboard/orders' && pendingCount > 0
+                            ? pendingCount
+                            : undefined
+                        }
                       />
                     ))}
                     {canSeeAdmin && (

--- a/apps/web/components/marketing/WaitlistDialog.tsx
+++ b/apps/web/components/marketing/WaitlistDialog.tsx
@@ -1,10 +1,10 @@
 'use client';
 
+import { zodResolver } from '@hookform/resolvers/zod';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
-import { z } from 'zod';
-import { zodResolver } from '@hookform/resolvers/zod';
 import { sileo } from 'sileo';
+import { z } from 'zod';
 
 import { Button } from '@/components/ui/button';
 import {
@@ -28,10 +28,9 @@ import { Input } from '@/components/ui/input';
 import {
   InputOTP,
   InputOTPGroup,
-  InputOTPSlot,
   InputOTPSeparator,
+  InputOTPSlot,
 } from '@/components/ui/input-otp';
-import { Textarea } from '@/components/ui/textarea';
 import {
   Select,
   SelectContent,
@@ -39,6 +38,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import { Textarea } from '@/components/ui/textarea';
 import { cn } from '@/lib/utils';
 
 const waitlistSchema = z.object({

--- a/apps/web/components/marketplace/ListingCard.tsx
+++ b/apps/web/components/marketplace/ListingCard.tsx
@@ -1,19 +1,19 @@
 'use client';
 
-import { useState } from 'react';
 import { Trash2 } from 'lucide-react';
+import { useState } from 'react';
 import { sileo } from 'sileo';
+import { TokenIcon } from '@/components/shared/TokenIcon';
+import { TradeTypeBadge } from '@/components/shared/TradeTypeBadge';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
-import { TokenIcon } from '@/components/shared/TokenIcon';
-import { TradeTypeBadge } from '@/components/shared/TradeTypeBadge';
-import { formatAmount, formatDate } from '@/lib/dashboard-utils';
-import { MarketplaceListing } from '@/lib/types/marketplace';
-import useGlobalAuthenticationStore from '@/store/wallet.store';
 import { useAuth } from '@/hooks/use-auth';
 import { useDeleteListing } from '@/hooks/use-listings';
+import { formatAmount, formatDate } from '@/lib/dashboard-utils';
+import type { MarketplaceListing } from '@/lib/types/marketplace';
+import useGlobalAuthenticationStore from '@/store/wallet.store';
 
 interface ListingCardProps {
   listing: MarketplaceListing;
@@ -67,11 +67,12 @@ export function ListingCard({ listing, onTrade }: ListingCardProps) {
                     <span className="text-xl font-semibold text-muted-foreground">
                       {listing.token}
                     </span>
-                    {listing.amountRemaining != null && listing.amountRemaining < listing.amount && (
-                      <span className="text-sm text-muted-foreground">
-                        of {formatAmount(listing.amount)} total
-                      </span>
-                    )}
+                    {listing.amountRemaining != null &&
+                      listing.amountRemaining < listing.amount && (
+                        <span className="text-sm text-muted-foreground">
+                          of {formatAmount(listing.amount)} total
+                        </span>
+                      )}
                   </div>
                   <div className="grid grid-cols-1 gap-4 text-sm sm:grid-cols-2">
                     <div>
@@ -144,7 +145,9 @@ export function ListingCard({ listing, onTrade }: ListingCardProps) {
                   Total Value
                 </p>
                 <p className="text-3xl font-bold text-foreground">
-                  {formatAmount((listing.amountRemaining ?? listing.amount) * listing.rate)}
+                  {formatAmount(
+                    (listing.amountRemaining ?? listing.amount) * listing.rate
+                  )}
                 </p>
                 <p className="text-lg font-semibold text-muted-foreground">
                   {listing.fiatCurrency}

--- a/apps/web/components/marketplace/ListingsTabs.tsx
+++ b/apps/web/components/marketplace/ListingsTabs.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { FC, ReactNode } from 'react';
 import { ShoppingCart } from 'lucide-react';
+import type { FC, ReactNode } from 'react';
 import { Card, CardContent } from '@/components/ui/card';
 import type { MarketplaceListing } from '@/lib/types/marketplace';
 import { ListingCard } from './ListingCard';

--- a/apps/web/components/marketplace/MarketStats.tsx
+++ b/apps/web/components/marketplace/MarketStats.tsx
@@ -2,7 +2,7 @@
 
 import { TrendingDown, TrendingUp } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { MarketStats as MarketStatsType } from '@/lib/types/marketplace';
+import type { MarketStats as MarketStatsType } from '@/lib/types/marketplace';
 
 interface MarketStatsProps {
   stats: MarketStatsType;
@@ -11,9 +11,16 @@ interface MarketStatsProps {
 function ChangeBadge({ value, suffix }: { value: number; suffix: string }) {
   const positive = value >= 0;
   return (
-    <p className={`text-sm flex items-center mt-1 ${positive ? 'text-emerald-500' : 'text-red-500'}`}>
-      {positive ? <TrendingUp className="w-4 h-4 mr-1" /> : <TrendingDown className="w-4 h-4 mr-1" />}
-      {positive ? '+' : ''}{value}% {suffix}
+    <p
+      className={`text-sm flex items-center mt-1 ${positive ? 'text-emerald-500' : 'text-red-500'}`}
+    >
+      {positive ? (
+        <TrendingUp className="w-4 h-4 mr-1" />
+      ) : (
+        <TrendingDown className="w-4 h-4 mr-1" />
+      )}
+      {positive ? '+' : ''}
+      {value}% {suffix}
     </p>
   );
 }
@@ -28,8 +35,13 @@ export function MarketStats({ stats }: MarketStatsProps) {
           </CardTitle>
         </CardHeader>
         <CardContent>
-          <div className="text-3xl font-bold text-foreground">{stats.activeListings}</div>
-          <ChangeBadge value={stats.activeListingsChange} suffix="vs last week" />
+          <div className="text-3xl font-bold text-foreground">
+            {stats.activeListings}
+          </div>
+          <ChangeBadge
+            value={stats.activeListingsChange}
+            suffix="vs last week"
+          />
         </CardContent>
       </Card>
 
@@ -41,7 +53,10 @@ export function MarketStats({ stats }: MarketStatsProps) {
         </CardHeader>
         <CardContent>
           <div className="text-3xl font-bold text-foreground">
-            ${stats.totalVolume24h.toLocaleString(undefined, { maximumFractionDigits: 2 })}
+            $
+            {stats.totalVolume24h.toLocaleString(undefined, {
+              maximumFractionDigits: 2,
+            })}
           </div>
           <ChangeBadge value={stats.volumeChange} suffix="vs yesterday" />
         </CardContent>
@@ -55,7 +70,10 @@ export function MarketStats({ stats }: MarketStatsProps) {
         </CardHeader>
         <CardContent>
           <div className="text-3xl font-bold text-foreground">
-            ${stats.avgTradeSize.toLocaleString(undefined, { maximumFractionDigits: 2 })}
+            $
+            {stats.avgTradeSize.toLocaleString(undefined, {
+              maximumFractionDigits: 2,
+            })}
           </div>
           <ChangeBadge value={stats.tradeSizeChange} suffix="vs last week" />
         </CardContent>

--- a/apps/web/components/marketplace/MarketplaceFilters.tsx
+++ b/apps/web/components/marketplace/MarketplaceFilters.tsx
@@ -8,7 +8,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { ListingFilters } from '@/lib/types/marketplace';
+import type { ListingFilters } from '@/lib/types/marketplace';
 
 interface MarketplaceFiltersProps {
   filters: ListingFilters;
@@ -44,10 +44,7 @@ export function MarketplaceFilters({
             className="w-full h-9 pl-9 pr-3 rounded-lg bg-white/[0.04] border border-white/[0.07] text-sm text-foreground placeholder:text-muted-foreground/50 outline-none focus:border-white/[0.15] transition-colors"
           />
         </div>
-        <Select
-          value={filters.selectedToken}
-          onValueChange={handleTokenChange}
-        >
+        <Select value={filters.selectedToken} onValueChange={handleTokenChange}>
           <SelectTrigger className="w-full sm:w-40 h-9 bg-white/[0.04] border-white/[0.07] text-sm">
             <SelectValue placeholder="Token" />
           </SelectTrigger>

--- a/apps/web/components/marketplace/TradeConfirmationDialog.tsx
+++ b/apps/web/components/marketplace/TradeConfirmationDialog.tsx
@@ -3,10 +3,9 @@
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 import { Check, ChevronDown, RefreshCw, X, XIcon } from 'lucide-react';
 import { useState } from 'react';
-
+import { TokenIcon } from '@/components/shared/TokenIcon';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { TokenIcon } from '@/components/shared/TokenIcon';
 import { formatAmount, formatCurrency } from '@/lib/dashboard-utils';
 import type { MarketplaceListing } from '@/lib/types/marketplace';
 import { cn } from '@/lib/utils';
@@ -48,10 +47,14 @@ export function TradeConfirmationDialog({
 
   const fiatAmount = parseFloat(amount) || 0;
   const cryptoAmount = fiatAmount / selectedListing.rate;
-  const availableAmount = selectedListing.amountRemaining ?? selectedListing.amount;
+  const availableAmount =
+    selectedListing.amountRemaining ?? selectedListing.amount;
   const maxAvailable =
     selectedListing.maxAmount != null
-      ? Math.min(selectedListing.maxAmount, availableAmount * selectedListing.rate)
+      ? Math.min(
+          selectedListing.maxAmount,
+          availableAmount * selectedListing.rate
+        )
       : availableAmount * selectedListing.rate;
   const minAmount = selectedListing.minAmount || 0;
   const isAmountValid =
@@ -97,226 +100,234 @@ export function TradeConfirmationDialog({
             </DialogPrimitive.Close>
           </div>
           <div className="overflow-y-auto flex-1">
-          <div className="grid grid-cols-1 lg:grid-cols-5 gap-0 h-full">
-            {/* Left Section - Advertisers' Terms */}
-            <div className="p-6 border-r border-border/50 lg:col-span-2">
-              {(selectedListing.description || getTerms().length > 0) && (
-                <h4 className="text-lg font-semibold text-foreground mb-4">
-                  Advertisers&apos; Terms
-                </h4>
-              )}
-
-              <div className="space-y-3 text-sm">
-                {selectedListing.description && (
-                  <div className="flex items-start gap-2">
-                    <span className="text-green-500 mt-0.5"></span>
-                    <p className="text-muted-foreground">
-                      {selectedListing.description}
-                    </p>
-                  </div>
+            <div className="grid grid-cols-1 lg:grid-cols-5 gap-0 h-full">
+              {/* Left Section - Advertisers' Terms */}
+              <div className="p-6 border-r border-border/50 lg:col-span-2">
+                {(selectedListing.description || getTerms().length > 0) && (
+                  <h4 className="text-lg font-semibold text-foreground mb-4">
+                    Advertisers&apos; Terms
+                  </h4>
                 )}
 
-                {getTerms().map((term, index) => (
-                  <div
-                    key={`term-${term.type}-${index}`}
-                    className="flex items-start gap-2"
-                  >
-                    {term.type === 'positive' ? (
-                      <Check className="w-4 h-4 text-green-500 mt-0.5 flex-shrink-0" />
-                    ) : (
-                      <X className="w-4 h-4 text-red-500 mt-0.5 flex-shrink-0" />
-                    )}
-                    <p className="text-muted-foreground">{term.text}</p>
-                  </div>
-                ))}
-              </div>
-            </div>
-
-            {/* Right Section - Transaction Form */}
-            <div className="p-6 bg-muted/20 lg:col-span-3">
-              <div className="h-full flex flex-col justify-center max-w-4xl mx-auto">
-                {/* Price Display */}
-                <div className="flex items-center justify-between p-4 bg-card/50 rounded-lg mb-6">
-                  <span className="text-sm text-muted-foreground">Price</span>
-                  <div className="flex items-center gap-2">
-                    <span className="font-semibold text-foreground">
-                      {selectedListing.fiatCurrency === 'CRC' ? '₡' : '$'}{' '}
-                      {Number(selectedListing.rate).toFixed(2)}{' '}
-                      {selectedListing.fiatCurrency}
-                    </span>
-                    <RefreshCw className="w-4 h-4 text-muted-foreground cursor-pointer hover:text-emerald-500 transition-colors" />
-                  </div>
-                </div>
-
-                {/* Horizontal Form Fields */}
-                <div className="grid grid-cols-2 gap-6 mb-6">
-                  {/* You Pay Input */}
-                  <div className="bg-card/50 border border-border/50 rounded-lg p-5">
-                    <div className="flex items-center justify-between mb-3">
-                      <span className="text-sm font-medium text-muted-foreground">
-                        You Pay
-                      </span>
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        className="h-8 px-4 text-xs"
-                        onClick={handleMaxAmount}
-                      >
-                        All
-                      </Button>
+                <div className="space-y-3 text-sm">
+                  {selectedListing.description && (
+                    <div className="flex items-start gap-2">
+                      <span className="text-green-500 mt-0.5"></span>
+                      <p className="text-muted-foreground">
+                        {selectedListing.description}
+                      </p>
                     </div>
-                    <Input
-                      type="text"
-                      value={amount}
-                      onChange={(e) => handleAmountChange(e.target.value)}
-                      className="text-3xl font-bold border-none bg-transparent p-0 h-auto focus-visible:ring-0"
-                      placeholder="0.00"
-                      onFocus={(e) => e.target.select()}
-                    />
-                    <div className="text-sm text-muted-foreground mt-2">
-                      {selectedListing.fiatCurrency} (Range:{' '}
-                      {formatCurrency(minAmount, selectedListing.fiatCurrency)}{' '}
-                      -{' '}
+                  )}
+
+                  {getTerms().map((term, index) => (
+                    <div
+                      key={`term-${term.type}-${index}`}
+                      className="flex items-start gap-2"
+                    >
+                      {term.type === 'positive' ? (
+                        <Check className="w-4 h-4 text-green-500 mt-0.5 flex-shrink-0" />
+                      ) : (
+                        <X className="w-4 h-4 text-red-500 mt-0.5 flex-shrink-0" />
+                      )}
+                      <p className="text-muted-foreground">{term.text}</p>
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              {/* Right Section - Transaction Form */}
+              <div className="p-6 bg-muted/20 lg:col-span-3">
+                <div className="h-full flex flex-col justify-center max-w-4xl mx-auto">
+                  {/* Price Display */}
+                  <div className="flex items-center justify-between p-4 bg-card/50 rounded-lg mb-6">
+                    <span className="text-sm text-muted-foreground">Price</span>
+                    <div className="flex items-center gap-2">
+                      <span className="font-semibold text-foreground">
+                        {selectedListing.fiatCurrency === 'CRC' ? '₡' : '$'}{' '}
+                        {Number(selectedListing.rate).toFixed(2)}{' '}
+                        {selectedListing.fiatCurrency}
+                      </span>
+                      <RefreshCw className="w-4 h-4 text-muted-foreground cursor-pointer hover:text-emerald-500 transition-colors" />
+                    </div>
+                  </div>
+
+                  {/* Horizontal Form Fields */}
+                  <div className="grid grid-cols-2 gap-6 mb-6">
+                    {/* You Pay Input */}
+                    <div className="bg-card/50 border border-border/50 rounded-lg p-5">
+                      <div className="flex items-center justify-between mb-3">
+                        <span className="text-sm font-medium text-muted-foreground">
+                          You Pay
+                        </span>
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          className="h-8 px-4 text-xs"
+                          onClick={handleMaxAmount}
+                        >
+                          All
+                        </Button>
+                      </div>
+                      <Input
+                        type="text"
+                        value={amount}
+                        onChange={(e) => handleAmountChange(e.target.value)}
+                        className="text-3xl font-bold border-none bg-transparent p-0 h-auto focus-visible:ring-0"
+                        placeholder="0.00"
+                        onFocus={(e) => e.target.select()}
+                      />
+                      <div className="text-sm text-muted-foreground mt-2">
+                        {selectedListing.fiatCurrency} (Range:{' '}
+                        {formatCurrency(
+                          minAmount,
+                          selectedListing.fiatCurrency
+                        )}{' '}
+                        -{' '}
+                        {formatCurrency(
+                          maxAvailable,
+                          selectedListing.fiatCurrency
+                        )}
+                        )
+                        {amount !== '' && fiatAmount < minAmount && (
+                          <div className="text-red-500 text-xs mt-1">
+                            Minimum amount is{' '}
+                            {formatCurrency(
+                              minAmount,
+                              selectedListing.fiatCurrency
+                            )}
+                          </div>
+                        )}
+                        {amount !== '' && fiatAmount > maxAvailable && (
+                          <div className="text-red-500 text-xs mt-1">
+                            Maximum amount is{' '}
+                            {formatCurrency(
+                              maxAvailable,
+                              selectedListing.fiatCurrency
+                            )}
+                          </div>
+                        )}
+                      </div>
+                    </div>
+
+                    {/* You Receive Input */}
+                    <div className="bg-card/50 border border-border/50 rounded-lg p-5">
+                      <div className="flex items-center justify-between mb-3">
+                        <span className="text-sm font-medium text-muted-foreground">
+                          You Receive
+                        </span>
+                        <div className="flex items-center gap-2">
+                          <span className="text-sm font-medium text-foreground">
+                            {selectedListing.token}
+                          </span>
+                          <TokenIcon token={selectedListing.token} size="sm" />
+                        </div>
+                      </div>
+                      <div className="text-3xl font-bold text-foreground">
+                        {formatAmount(cryptoAmount)}
+                      </div>
+                    </div>
+                  </div>
+
+                  {/* Available Amount Display */}
+                  <div className="text-center mb-6">
+                    <div className="text-2xl font-bold text-foreground">
                       {formatCurrency(
                         maxAvailable,
                         selectedListing.fiatCurrency
                       )}
-                      )
-                      {amount !== '' && fiatAmount < minAmount && (
-                        <div className="text-red-500 text-xs mt-1">
-                          Minimum amount is{' '}
-                          {formatCurrency(
-                            minAmount,
-                            selectedListing.fiatCurrency
-                          )}
-                        </div>
-                      )}
-                      {amount !== '' && fiatAmount > maxAvailable && (
-                        <div className="text-red-500 text-xs mt-1">
-                          Maximum amount is{' '}
-                          {formatCurrency(
-                            maxAvailable,
-                            selectedListing.fiatCurrency
-                          )}
-                        </div>
-                      )}
+                    </div>
+                    <div className="text-sm text-muted-foreground mt-1">
+                      Max available from seller
                     </div>
                   </div>
 
-                  {/* You Receive Input */}
-                  <div className="bg-card/50 border border-border/50 rounded-lg p-5">
-                    <div className="flex items-center justify-between mb-3">
+                  {/* Payment Method Selection */}
+                  <div className="bg-card/50 border border-border/50 rounded-lg p-5 mb-6">
+                    <div className="flex items-center justify-between">
                       <span className="text-sm font-medium text-muted-foreground">
-                        You Receive
-                      </span>
-                      <div className="flex items-center gap-2">
-                        <span className="text-sm font-medium text-foreground">
-                          {selectedListing.token}
-                        </span>
-                        <TokenIcon token={selectedListing.token} size="sm" />
-                      </div>
-                    </div>
-                    <div className="text-3xl font-bold text-foreground">
-                      {formatAmount(cryptoAmount)}
-                    </div>
-                  </div>
-                </div>
-
-                {/* Available Amount Display */}
-                <div className="text-center mb-6">
-                  <div className="text-2xl font-bold text-foreground">
-                    {formatCurrency(maxAvailable, selectedListing.fiatCurrency)}
-                  </div>
-                  <div className="text-sm text-muted-foreground mt-1">
-                    Max available from seller
-                  </div>
-                </div>
-
-                {/* Payment Method Selection */}
-                <div className="bg-card/50 border border-border/50 rounded-lg p-5 mb-6">
-                  <div className="flex items-center justify-between">
-                    <span className="text-sm font-medium text-muted-foreground">
-                      {selectedPaymentMethod
-                        ? `${paymentMethods.find((m) => m.id === selectedPaymentMethod)?.name} - ${selectedListing.fiatCurrency}`
-                        : 'Set my payment method'}
-                    </span>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => setShowPaymentMethods(!showPaymentMethods)}
-                      className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground"
-                    >
-                      <span>
                         {selectedPaymentMethod
-                          ? paymentMethods.length - 1
-                          : paymentMethods.length}
+                          ? `${paymentMethods.find((m) => m.id === selectedPaymentMethod)?.name} - ${selectedListing.fiatCurrency}`
+                          : 'Set my payment method'}
                       </span>
-                      <ChevronDown
-                        className={cn(
-                          'w-4 h-4 transition-transform',
-                          showPaymentMethods && 'rotate-180'
-                        )}
-                      />
-                    </Button>
-                  </div>
-
-                  {showPaymentMethods && (
-                    <div className="mt-4 space-y-2">
-                      {paymentMethods.map((method) => (
-                        <button
-                          key={method.id}
-                          type="button"
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() =>
+                          setShowPaymentMethods(!showPaymentMethods)
+                        }
+                        className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground"
+                      >
+                        <span>
+                          {selectedPaymentMethod
+                            ? paymentMethods.length - 1
+                            : paymentMethods.length}
+                        </span>
+                        <ChevronDown
                           className={cn(
-                            'flex items-center gap-3 p-3 rounded-lg cursor-pointer transition-colors w-full text-left',
-                            selectedPaymentMethod === method.id
-                              ? 'bg-emerald-500/10 border border-emerald-500/20'
-                              : 'hover:bg-muted/50'
+                            'w-4 h-4 transition-transform',
+                            showPaymentMethods && 'rotate-180'
                           )}
-                          onClick={() => {
-                            setSelectedPaymentMethod(method.id);
-                            setShowPaymentMethods(false);
-                          }}
-                          onKeyDown={(e) => {
-                            if (e.key === 'Enter' || e.key === ' ') {
+                        />
+                      </Button>
+                    </div>
+
+                    {showPaymentMethods && (
+                      <div className="mt-4 space-y-2">
+                        {paymentMethods.map((method) => (
+                          <button
+                            key={method.id}
+                            type="button"
+                            className={cn(
+                              'flex items-center gap-3 p-3 rounded-lg cursor-pointer transition-colors w-full text-left',
+                              selectedPaymentMethod === method.id
+                                ? 'bg-emerald-500/10 border border-emerald-500/20'
+                                : 'hover:bg-muted/50'
+                            )}
+                            onClick={() => {
                               setSelectedPaymentMethod(method.id);
                               setShowPaymentMethods(false);
-                            }
-                          }}
-                        >
-                          <span className="text-lg"></span>
-                          <span className="text-sm font-medium">
-                            {method.name}
-                          </span>
-                          {selectedPaymentMethod === method.id && (
-                            <Check className="w-4 h-4 text-emerald-500 ml-auto" />
-                          )}
-                        </button>
-                      ))}
-                    </div>
-                  )}
-                </div>
+                            }}
+                            onKeyDown={(e) => {
+                              if (e.key === 'Enter' || e.key === ' ') {
+                                setSelectedPaymentMethod(method.id);
+                                setShowPaymentMethods(false);
+                              }
+                            }}
+                          >
+                            <span className="text-lg"></span>
+                            <span className="text-sm font-medium">
+                              {method.name}
+                            </span>
+                            {selectedPaymentMethod === method.id && (
+                              <Check className="w-4 h-4 text-emerald-500 ml-auto" />
+                            )}
+                          </button>
+                        ))}
+                      </div>
+                    )}
+                  </div>
 
-                {/* Buy Button */}
-                <Button
-                  onClick={() =>
-                    onConfirm({
-                      fiatAmount,
-                      cryptoAmount,
-                      paymentMethod: selectedPaymentMethod,
-                    })
-                  }
-                  className="w-full bg-emerald-600 hover:bg-emerald-700 text-white font-semibold py-5 rounded-lg text-lg"
-                  disabled={
-                    isPending || !isAmountValid || !selectedPaymentMethod
-                  }
-                >
-                  {isPending
-                    ? 'Creating Escrow...'
-                    : `Buy ${selectedListing.token}`}
-                </Button>
+                  {/* Buy Button */}
+                  <Button
+                    onClick={() =>
+                      onConfirm({
+                        fiatAmount,
+                        cryptoAmount,
+                        paymentMethod: selectedPaymentMethod,
+                      })
+                    }
+                    className="w-full bg-emerald-600 hover:bg-emerald-700 text-white font-semibold py-5 rounded-lg text-lg"
+                    disabled={
+                      isPending || !isAmountValid || !selectedPaymentMethod
+                    }
+                  >
+                    {isPending
+                      ? 'Creating Escrow...'
+                      : `Buy ${selectedListing.token}`}
+                  </Button>
+                </div>
               </div>
             </div>
-          </div>
           </div>
         </DialogPrimitive.Content>
       </DialogPrimitive.Portal>

--- a/apps/web/components/marketplace/index.ts
+++ b/apps/web/components/marketplace/index.ts
@@ -1,5 +1,5 @@
 export { ListingCard } from './ListingCard';
+export { ListingsTabs } from './ListingsTabs';
 export { MarketplaceFilters } from './MarketplaceFilters';
 export { MarketStats } from './MarketStats';
 export { TradeConfirmationDialog } from './TradeConfirmationDialog';
-export { ListingsTabs } from './ListingsTabs';

--- a/apps/web/components/merchant/BadgeGrid.tsx
+++ b/apps/web/components/merchant/BadgeGrid.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { motion } from 'framer-motion';
-import { Card } from '@/components/ui/card';
 import { Badge as UiBadge } from '@/components/ui/badge';
+import { Card } from '@/components/ui/card';
 import {
   Tooltip,
   TooltipContent,

--- a/apps/web/components/merchant/CreateListingForm.tsx
+++ b/apps/web/components/merchant/CreateListingForm.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useForm, type Resolver } from 'react-hook-form';
+import Link from 'next/link';
+import { type Resolver, useForm } from 'react-hook-form';
 import { sileo } from 'sileo';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
@@ -23,20 +24,19 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
-import { TRUSTLINES } from '@/utils/constants/trustlines';
-import { useCreateListing } from '@/hooks/use-listings';
 import { useAuth } from '@/hooks/use-auth';
-import { useMeMerchant } from '../../hooks/useMerchant';
-import {
-  listingFormSchema,
-  LISTING_FORM_DEFAULT_VALUES,
-  type ListingFormValues,
-} from '@/lib/schemas/listing/listing-form-schema';
+import { useCreateListing } from '@/hooks/use-listings';
 import {
   toCreateListingData,
   type UIListingFormInput,
 } from '@/lib/marketplace-utils';
-import Link from 'next/link';
+import {
+  LISTING_FORM_DEFAULT_VALUES,
+  type ListingFormValues,
+  listingFormSchema,
+} from '@/lib/schemas/listing/listing-form-schema';
+import { TRUSTLINES } from '@/utils/constants/trustlines';
+import { useMeMerchant } from '../../hooks/useMerchant';
 
 export function CreateListingForm({ onCreated }: { onCreated?: () => void }) {
   const { data: merchant, isLoading: merchantLoading } = useMeMerchant();

--- a/apps/web/components/merchant/CreateListingModal.tsx
+++ b/apps/web/components/merchant/CreateListingModal.tsx
@@ -2,9 +2,17 @@
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import { ArrowLeft, Loader2 } from 'lucide-react';
+import Link from 'next/link';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { FormProvider, useForm, type Resolver } from 'react-hook-form';
+import { FormProvider, type Resolver, useForm } from 'react-hook-form';
 import { sileo } from 'sileo';
+import { CreateListingProgress } from '@/components/merchant/CreateListingProgress';
+import {
+  PaymentLimitsStep,
+  PricingStep,
+  ReviewStep,
+  TradeTypeStep,
+} from '@/components/merchant/steps';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,
@@ -15,30 +23,22 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { Form } from '@/components/ui/form';
-import { useCreateListing } from '@/hooks/use-listings';
 import { useAuth } from '@/hooks/use-auth';
-import useGlobalAuthenticationStore from '@/store/wallet.store';
-import { useMeMerchant } from '../../hooks/useMerchant';
-import {
-  listingFormSchema,
-  LISTING_FORM_DEFAULT_VALUES,
-  STEP_1_FIELDS,
-  STEP_2_FIELDS,
-  STEP_3_FIELDS,
-  type ListingFormValues,
-} from '@/lib/schemas/listing/listing-form-schema';
+import { useCreateListing } from '@/hooks/use-listings';
 import {
   toCreateListingData,
   type UIListingFormInput,
 } from '@/lib/marketplace-utils';
-import { CreateListingProgress } from '@/components/merchant/CreateListingProgress';
 import {
-  TradeTypeStep,
-  PricingStep,
-  PaymentLimitsStep,
-  ReviewStep,
-} from '@/components/merchant/steps';
-import Link from 'next/link';
+  LISTING_FORM_DEFAULT_VALUES,
+  type ListingFormValues,
+  listingFormSchema,
+  STEP_1_FIELDS,
+  STEP_2_FIELDS,
+  STEP_3_FIELDS,
+} from '@/lib/schemas/listing/listing-form-schema';
+import useGlobalAuthenticationStore from '@/store/wallet.store';
+import { useMeMerchant } from '../../hooks/useMerchant';
 
 type Step = 1 | 2 | 3 | 4;
 
@@ -64,7 +64,8 @@ export function CreateListingModal({
   });
 
   const tradeType = form.watch('type');
-  const modalTitle = tradeType === 'buy' ? 'Create Buy Listing' : 'Create Sell Listing';
+  const modalTitle =
+    tradeType === 'buy' ? 'Create Buy Listing' : 'Create Sell Listing';
 
   const createListing = useCreateListing();
   const { user } = useAuth();
@@ -143,7 +144,8 @@ export function CreateListingModal({
     if (!walletAddress) {
       sileo.error({
         title: 'Connect your Stellar wallet first.',
-        description: 'Use the wallet button in the header to connect before creating a listing.',
+        description:
+          'Use the wallet button in the header to connect before creating a listing.',
       });
       return;
     }

--- a/apps/web/components/merchant/CreateListingProgress.tsx
+++ b/apps/web/components/merchant/CreateListingProgress.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { cn } from '@/lib/utils';
 import { Progress } from '@/components/ui/progress';
+import { cn } from '@/lib/utils';
 
 const STEP_LABELS = ['Type & Asset', 'Pricing', 'Payment', 'Review'] as const;
 

--- a/apps/web/components/merchant/ListingsTable.tsx
+++ b/apps/web/components/merchant/ListingsTable.tsx
@@ -2,9 +2,9 @@
 
 import { ArrowUpDown } from 'lucide-react';
 import { useMemo, useState } from 'react';
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
 import type { MerchantListing } from '@/lib/types/merchant';
 
 type SortKey = keyof Pick<

--- a/apps/web/components/merchant/MerchantApplicationModal.tsx
+++ b/apps/web/components/merchant/MerchantApplicationModal.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { zodResolver } from '@hookform/resolvers/zod';
+import { Loader2 } from 'lucide-react';
 import { useForm } from 'react-hook-form';
 import { sileo } from 'sileo';
 import { z } from 'zod';
@@ -21,9 +22,8 @@ import {
   FormMessage,
 } from '@/components/ui/form';
 import { Textarea } from '@/components/ui/textarea';
-import { useMerchantApplication } from '@/hooks/useMerchant';
 import { useAuth } from '@/hooks/use-auth';
-import { Loader2 } from 'lucide-react';
+import { useMerchantApplication } from '@/hooks/useMerchant';
 
 const applicationSchema = z.object({
   bio: z

--- a/apps/web/components/merchant/MerchantGuard.tsx
+++ b/apps/web/components/merchant/MerchantGuard.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import React from 'react';
+import type React from 'react';
 import { useMerchantStatus } from '../../hooks/useMerchant';
 
 interface MerchantGuardProps {

--- a/apps/web/components/merchant/MerchantProfileForm.tsx
+++ b/apps/web/components/merchant/MerchantProfileForm.tsx
@@ -1,7 +1,11 @@
 'use client';
 
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useForm, type Resolver } from 'react-hook-form';
+import { countries as countriesData } from 'countries-list';
+import { X } from 'lucide-react';
+import Image from 'next/image';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { type Resolver, useForm } from 'react-hook-form';
 import { sileo } from 'sileo';
 import { z } from 'zod';
 import { Button } from '@/components/ui/button';
@@ -15,13 +19,7 @@ import {
   FormMessage,
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
-import { Switch } from '@/components/ui/switch';
-import { Textarea } from '@/components/ui/textarea';
-import { useUpsertMerchantProfile } from '@/hooks/useMerchant';
-import type { Merchant } from '@/lib/types/merchant';
-import useGlobalAuthenticationStore from '@/store/wallet.store';
-import { useWallet } from '@/hooks/use-wallet';
-import { useAuth } from '@/hooks/use-auth';
+import { Label } from '@/components/ui/label';
 import {
   Select,
   SelectContent,
@@ -29,12 +27,14 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import { Textarea } from '@/components/ui/textarea';
+import { useAuth } from '@/hooks/use-auth';
+import { useWallet } from '@/hooks/use-wallet';
+import { useUpsertMerchantProfile } from '@/hooks/useMerchant';
 import { supabase } from '@/lib/supabase';
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { X } from 'lucide-react';
-import Image from 'next/image';
-import { countries as countriesData } from 'countries-list';
+import type { Merchant } from '@/lib/types/merchant';
+import useGlobalAuthenticationStore from '@/store/wallet.store';
 
 const schema = z.object({
   display_name: z.string().min(2, 'Display name is required'),

--- a/apps/web/components/merchant/TokenPickerModal.tsx
+++ b/apps/web/components/merchant/TokenPickerModal.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { useState } from 'react';
 import { Search, X } from 'lucide-react';
-import { TRUSTLINES } from '@/utils/constants/trustlines';
+import { useState } from 'react';
 import { TokenIcon } from '@/components/shared/TokenIcon';
+import { TRUSTLINES } from '@/utils/constants/trustlines';
 
 const AVAILABLE = TRUSTLINES.filter((t) => !!t.address);
 

--- a/apps/web/components/merchant/steps/PaymentLimitsStep.tsx
+++ b/apps/web/components/merchant/steps/PaymentLimitsStep.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useState, useRef, useEffect } from 'react';
 import { ChevronDown } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
 import {
   FormControl,
@@ -16,7 +16,11 @@ import type { ListingFormValues } from '@/lib/schemas/listing/listing-form-schem
 const PAYMENT_METHODS = [
   { value: 'SINPE', label: 'SINPE', description: 'Costa Rica' },
   { value: 'SPEI', label: 'SPEI', description: 'Mexico' },
-  { value: 'Bank Transfer', label: 'Bank Transfer', description: 'International' },
+  {
+    value: 'Bank Transfer',
+    label: 'Bank Transfer',
+    description: 'International',
+  },
   { value: 'Cash Deposit', label: 'Cash Deposit', description: 'In person' },
 ];
 
@@ -26,13 +30,19 @@ export function PaymentLimitsStep() {
   const methodRef = useRef<HTMLDivElement>(null);
 
   const type = useWatch({ control: form.control, name: 'type' });
-  const fiatCurrency = useWatch({ control: form.control, name: 'fiatCurrency' });
+  const fiatCurrency = useWatch({
+    control: form.control,
+    name: 'fiatCurrency',
+  });
   const amount = useWatch({ control: form.control, name: 'amount' });
   const rate = useWatch({ control: form.control, name: 'rate' });
   const isSell = type === 'sell';
 
   const totalFiat =
-    amount && rate && !Number.isNaN(Number(amount)) && !Number.isNaN(Number(rate))
+    amount &&
+    rate &&
+    !Number.isNaN(Number(amount)) &&
+    !Number.isNaN(Number(rate))
       ? Number(amount) * Number(rate)
       : null;
 
@@ -54,7 +64,9 @@ export function PaymentLimitsStep() {
         name="paymentMethod"
         render={({ field }) => (
           <FormItem>
-            <FormLabel>{isSell ? 'How buyers will pay you' : 'How you will pay sellers'}</FormLabel>
+            <FormLabel>
+              {isSell ? 'How buyers will pay you' : 'How you will pay sellers'}
+            </FormLabel>
             <FormControl>
               <div ref={methodRef} className="relative">
                 <button
@@ -63,9 +75,14 @@ export function PaymentLimitsStep() {
                   className="flex h-9 w-full items-center justify-between rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs outline-none hover:border-ring transition-colors"
                 >
                   {field.value ? (
-                    <span>{PAYMENT_METHODS.find((m) => m.value === field.value)?.label ?? field.value}</span>
+                    <span>
+                      {PAYMENT_METHODS.find((m) => m.value === field.value)
+                        ?.label ?? field.value}
+                    </span>
                   ) : (
-                    <span className="text-muted-foreground">Select payment method</span>
+                    <span className="text-muted-foreground">
+                      Select payment method
+                    </span>
                   )}
                   <ChevronDown className="w-4 h-4 text-muted-foreground" />
                 </button>
@@ -84,7 +101,9 @@ export function PaymentLimitsStep() {
                         }`}
                       >
                         <span className="font-medium">{m.label}</span>
-                        <span className="text-muted-foreground text-xs">{m.description}</span>
+                        <span className="text-muted-foreground text-xs">
+                          {m.description}
+                        </span>
                       </button>
                     ))}
                   </div>
@@ -118,7 +137,9 @@ export function PaymentLimitsStep() {
             name="minAmount"
             render={({ field }) => (
               <FormItem>
-                <FormLabel className="text-xs text-muted-foreground">Min (Optional)</FormLabel>
+                <FormLabel className="text-xs text-muted-foreground">
+                  Min (Optional)
+                </FormLabel>
                 <FormControl>
                   <Input
                     type="number"
@@ -136,7 +157,9 @@ export function PaymentLimitsStep() {
             name="maxAmount"
             render={({ field }) => (
               <FormItem>
-                <FormLabel className="text-xs text-muted-foreground">Max (Optional)</FormLabel>
+                <FormLabel className="text-xs text-muted-foreground">
+                  Max (Optional)
+                </FormLabel>
                 <FormControl>
                   <Input
                     type="number"
@@ -144,7 +167,10 @@ export function PaymentLimitsStep() {
                     max={totalFiat ?? undefined}
                     {...field}
                     onChange={(e) => {
-                      if (totalFiat !== null && Number(e.target.value) > totalFiat) {
+                      if (
+                        totalFiat !== null &&
+                        Number(e.target.value) > totalFiat
+                      ) {
                         field.onChange(String(totalFiat));
                       } else {
                         field.onChange(e.target.value);

--- a/apps/web/components/merchant/steps/PricingStep.tsx
+++ b/apps/web/components/merchant/steps/PricingStep.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useState, useRef, useEffect } from 'react';
 import { Calculator, ChevronDown } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
 import {
   FormControl,
@@ -28,7 +28,10 @@ export function PricingStep() {
   const rate = useWatch({ control: form.control, name: 'rate' });
   const token = useWatch({ control: form.control, name: 'token' });
   const type = useWatch({ control: form.control, name: 'type' });
-  const fiatCurrency = useWatch({ control: form.control, name: 'fiatCurrency' });
+  const fiatCurrency = useWatch({
+    control: form.control,
+    name: 'fiatCurrency',
+  });
   const isSell = type === 'sell';
 
   const total =
@@ -41,19 +44,24 @@ export function PricingStep() {
 
   useEffect(() => {
     function handleClickOutside(e: MouseEvent) {
-      if (currencyRef.current && !currencyRef.current.contains(e.target as Node)) {
+      if (
+        currencyRef.current &&
+        !currencyRef.current.contains(e.target as Node)
+      ) {
         setCurrencyOpen(false);
       }
     }
-    if (currencyOpen) document.addEventListener('mousedown', handleClickOutside);
+    if (currencyOpen)
+      document.addEventListener('mousedown', handleClickOutside);
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, [currencyOpen]);
 
-  const rateLabel = token && fiatCurrency
-    ? `Price per 1 ${token} (${fiatCurrency})`
-    : token
-      ? `Price per 1 ${token}`
-      : 'Price per Token';
+  const rateLabel =
+    token && fiatCurrency
+      ? `Price per 1 ${token} (${fiatCurrency})`
+      : token
+        ? `Price per 1 ${token}`
+        : 'Price per Token';
 
   const rateHint = isSell
     ? 'How much fiat you will receive per token'
@@ -79,10 +87,13 @@ export function PricingStep() {
                   >
                     {field.value ? (
                       <span>
-                        {CURRENCIES.find((c) => c.value === field.value)?.label ?? field.value}
+                        {CURRENCIES.find((c) => c.value === field.value)
+                          ?.label ?? field.value}
                       </span>
                     ) : (
-                      <span className="text-muted-foreground">Select currency</span>
+                      <span className="text-muted-foreground">
+                        Select currency
+                      </span>
                     )}
                     <ChevronDown className="w-4 h-4 text-muted-foreground" />
                   </button>
@@ -101,7 +112,9 @@ export function PricingStep() {
                           }`}
                         >
                           <span className="font-medium">{c.label}</span>
-                          <span className="text-muted-foreground text-xs">{c.description}</span>
+                          <span className="text-muted-foreground text-xs">
+                            {c.description}
+                          </span>
                         </button>
                       ))}
                     </div>

--- a/apps/web/components/merchant/steps/ReviewStep.tsx
+++ b/apps/web/components/merchant/steps/ReviewStep.tsx
@@ -28,11 +28,13 @@ export function ReviewStep() {
   return (
     <div className="space-y-4">
       {/* Direction badge */}
-      <div className={`rounded-lg px-4 py-3 text-sm font-medium border ${
-        isSell
-          ? 'bg-emerald-500/10 border-emerald-500/20 text-emerald-700 dark:text-emerald-400'
-          : 'bg-blue-500/10 border-blue-500/20 text-blue-700 dark:text-blue-400'
-      }`}>
+      <div
+        className={`rounded-lg px-4 py-3 text-sm font-medium border ${
+          isSell
+            ? 'bg-emerald-500/10 border-emerald-500/20 text-emerald-700 dark:text-emerald-400'
+            : 'bg-blue-500/10 border-blue-500/20 text-blue-700 dark:text-blue-400'
+        }`}
+      >
         {isSell
           ? `You are selling ${values.amount || '—'} ${values.token || '—'} — receiving ${total} ${fiatCurrency}`
           : `You are buying ${values.amount || '—'} ${values.token || '—'} — paying ${total} ${fiatCurrency}`}
@@ -48,17 +50,23 @@ export function ReviewStep() {
           <span className="font-medium">{values.token}</span>
         </div>
         <div className="flex justify-between">
-          <span className="text-muted-foreground">{isSell ? 'Amount to sell' : 'Amount to buy'}</span>
+          <span className="text-muted-foreground">
+            {isSell ? 'Amount to sell' : 'Amount to buy'}
+          </span>
           <span className="font-medium">{values.amount || '—'}</span>
         </div>
         <div className="flex justify-between">
-          <span className="text-muted-foreground">{isSell ? 'Rate (you receive)' : 'Rate (you pay)'}</span>
+          <span className="text-muted-foreground">
+            {isSell ? 'Rate (you receive)' : 'Rate (you pay)'}
+          </span>
           <span className="font-medium">
             {values.rate || '—'} {fiatCurrency}
           </span>
         </div>
         <div className="flex justify-between">
-          <span className="text-muted-foreground">{isSell ? 'Total to receive' : 'Total to pay'}</span>
+          <span className="text-muted-foreground">
+            {isSell ? 'Total to receive' : 'Total to pay'}
+          </span>
           <span className="font-medium">
             {total} {fiatCurrency}
           </span>
@@ -71,7 +79,8 @@ export function ReviewStep() {
           <div className="flex justify-between">
             <span className="text-muted-foreground">Order Limits</span>
             <span className="font-medium">
-              {values.minAmount || '—'} / {values.maxAmount || '—'} {fiatCurrency}
+              {values.minAmount || '—'} / {values.maxAmount || '—'}{' '}
+              {fiatCurrency}
             </span>
           </div>
         )}

--- a/apps/web/components/merchant/steps/TradeTypeStep.tsx
+++ b/apps/web/components/merchant/steps/TradeTypeStep.tsx
@@ -1,8 +1,10 @@
 'use client';
 
-import { useState } from 'react';
 import { ChevronDown } from 'lucide-react';
+import { useState } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
+import { TokenPickerModal } from '@/components/merchant/TokenPickerModal';
+import { TokenIcon } from '@/components/shared/TokenIcon';
 import {
   FormControl,
   FormField,
@@ -12,8 +14,6 @@ import {
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
-import { TokenPickerModal } from '@/components/merchant/TokenPickerModal';
-import { TokenIcon } from '@/components/shared/TokenIcon';
 import type { ListingFormValues } from '@/lib/schemas/listing/listing-form-schema';
 
 export function TradeTypeStep() {
@@ -52,11 +52,13 @@ export function TradeTypeStep() {
       />
 
       {/* Context banner */}
-      <div className={`rounded-lg px-4 py-3 text-sm border ${
-        isSell
-          ? 'bg-emerald-500/10 border-emerald-500/20 text-emerald-700 dark:text-emerald-400'
-          : 'bg-blue-500/10 border-blue-500/20 text-blue-700 dark:text-blue-400'
-      }`}>
+      <div
+        className={`rounded-lg px-4 py-3 text-sm border ${
+          isSell
+            ? 'bg-emerald-500/10 border-emerald-500/20 text-emerald-700 dark:text-emerald-400'
+            : 'bg-blue-500/10 border-blue-500/20 text-blue-700 dark:text-blue-400'
+        }`}
+      >
         {isSell
           ? 'You are offering to sell your crypto — buyers will pay you in fiat.'
           : 'You are looking to buy crypto — you will pay sellers in fiat.'}
@@ -101,7 +103,9 @@ export function TradeTypeStep() {
           name="amount"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>{isSell ? 'Amount to sell' : 'Amount to buy'}</FormLabel>
+              <FormLabel>
+                {isSell ? 'Amount to sell' : 'Amount to buy'}
+              </FormLabel>
               <FormControl>
                 <Input type="number" placeholder="0.00" {...field} />
               </FormControl>

--- a/apps/web/components/merchant/steps/index.ts
+++ b/apps/web/components/merchant/steps/index.ts
@@ -1,4 +1,4 @@
-export { TradeTypeStep } from './TradeTypeStep';
-export { PricingStep } from './PricingStep';
 export { PaymentLimitsStep } from './PaymentLimitsStep';
+export { PricingStep } from './PricingStep';
 export { ReviewStep } from './ReviewStep';
+export { TradeTypeStep } from './TradeTypeStep';

--- a/apps/web/components/profile/MerchantSection.tsx
+++ b/apps/web/components/profile/MerchantSection.tsx
@@ -1,7 +1,10 @@
 'use client';
 
-import { useState } from 'react';
+import { AlertTriangle, CheckCircle, Clock, XCircle } from 'lucide-react';
 import Link from 'next/link';
+import { useState } from 'react';
+import { MerchantApplicationModal } from '@/components/merchant/MerchantApplicationModal';
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
   Card,
@@ -10,10 +13,7 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
 import { useMeMerchant } from '@/hooks/useMerchant';
-import { MerchantApplicationModal } from '@/components/merchant/MerchantApplicationModal';
-import { Clock, CheckCircle, XCircle, AlertTriangle } from 'lucide-react';
 
 export function MerchantSection() {
   const [showApplicationModal, setShowApplicationModal] = useState(false);

--- a/apps/web/components/profile/NotificationSettings.tsx
+++ b/apps/web/components/profile/NotificationSettings.tsx
@@ -12,7 +12,7 @@ import { Label } from '@/components/ui/label';
 import { Separator } from '@/components/ui/separator';
 import { Switch } from '@/components/ui/switch';
 
-import { NotificationSettingsData } from './types';
+import type { NotificationSettingsData } from './types';
 
 interface NotificationSettingsProps {
   notifications: NotificationSettingsData;

--- a/apps/web/components/profile/ProfileInfo.tsx
+++ b/apps/web/components/profile/ProfileInfo.tsx
@@ -8,8 +8,9 @@ import {
   User,
   X,
 } from 'lucide-react';
-import { useState, useCallback, useRef } from 'react';
 import Image from 'next/image';
+import { useCallback, useRef, useState } from 'react';
+import { sileo } from 'sileo';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -23,11 +24,9 @@ import {
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
-import { sileo } from 'sileo';
-import { supabase } from '@/lib/supabase';
-
-import type { ProfileData } from './types';
 import { fieldValidators } from '@/lib/schemas/profile-validation.schema';
+import { supabase } from '@/lib/supabase';
+import type { ProfileData } from './types';
 
 const ACCEPTED_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
 const MAX_FILE_SIZE_MB = 5;

--- a/apps/web/components/profile/SecuritySettings.tsx
+++ b/apps/web/components/profile/SecuritySettings.tsx
@@ -14,7 +14,7 @@ import { Label } from '@/components/ui/label';
 import { Separator } from '@/components/ui/separator';
 import { Switch } from '@/components/ui/switch';
 
-import { SecuritySettingsData } from './types';
+import type { SecuritySettingsData } from './types';
 
 interface SecuritySettingsProps {
   security: SecuritySettingsData;

--- a/apps/web/components/profile/index.ts
+++ b/apps/web/components/profile/index.ts
@@ -1,6 +1,6 @@
+export { MerchantSection } from './MerchantSection';
+export { NotificationSettings } from './NotificationSettings';
+export { PaymentMethods } from './PaymentMethods';
 export { ProfileInfo } from './ProfileInfo';
 export { ProfileStats } from './ProfileStats';
-export { PaymentMethods } from './PaymentMethods';
-export { NotificationSettings } from './NotificationSettings';
 export { SecuritySettings } from './SecuritySettings';
-export { MerchantSection } from './MerchantSection';

--- a/apps/web/components/shared/ListingEditDialog.tsx
+++ b/apps/web/components/shared/ListingEditDialog.tsx
@@ -11,8 +11,8 @@ import {
 } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import type { DashboardListing } from '@/lib/types';
 import { useUpdateListing } from '@/hooks/use-listings';
+import type { DashboardListing } from '@/lib/types';
 
 interface ListingEditDialogProps {
   open: boolean;

--- a/apps/web/components/shared/TokenIcon.tsx
+++ b/apps/web/components/shared/TokenIcon.tsx
@@ -36,7 +36,11 @@ export function TokenIcon({ token, size = 'md', className }: TokenIconProps) {
         src={logoUrl}
         alt={symbol}
         onError={() => setImgError(true)}
-        className={cn('rounded-full object-cover', sizeClasses[size], className)}
+        className={cn(
+          'rounded-full object-cover',
+          sizeClasses[size],
+          className
+        )}
       />
     );
   }

--- a/apps/web/components/shared/WalletConnectionPrompt.tsx
+++ b/apps/web/components/shared/WalletConnectionPrompt.tsx
@@ -1,7 +1,9 @@
 'use client';
 
 import { Wallet } from 'lucide-react';
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
+import { sileo } from 'sileo';
+import { Button } from '@/components/ui/button';
 import {
   Dialog,
   DialogContent,
@@ -9,11 +11,9 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
-import { Button } from '@/components/ui/button';
 import { useAuth } from '@/hooks/use-auth';
 import { useWallet } from '@/hooks/use-wallet';
 import { AuthService } from '@/lib/services/auth';
-import { sileo } from 'sileo';
 import useGlobalAuthenticationStore from '@/store/wallet.store';
 
 interface WalletConnectionPromptProps {

--- a/apps/web/components/shared/WalletInfo.tsx
+++ b/apps/web/components/shared/WalletInfo.tsx
@@ -12,11 +12,11 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
+import { useAuth } from '@/hooks/use-auth';
+import { useWallet } from '@/hooks/use-wallet';
+import { AuthService } from '@/lib/services/auth';
 import { cn } from '@/lib/utils';
 import useGlobalAuthenticationStore from '@/store/wallet.store';
-import { useWallet } from '@/hooks/use-wallet';
-import { useAuth } from '@/hooks/use-auth';
-import { AuthService } from '@/lib/services/auth';
 
 interface WalletInfoProps {
   showDetails?: boolean;

--- a/apps/web/components/ui/button.tsx
+++ b/apps/web/components/ui/button.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
 import { Slot } from '@radix-ui/react-slot';
 import { cva, type VariantProps } from 'class-variance-authority';
+import * as React from 'react';
 
 import { cn } from '@/lib/utils';
 

--- a/apps/web/components/ui/input-otp.tsx
+++ b/apps/web/components/ui/input-otp.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import * as React from 'react';
 import { OTPInput, OTPInputContext } from 'input-otp';
 import { Minus } from 'lucide-react';
+import * as React from 'react';
 
 import { cn } from '@/lib/utils';
 

--- a/apps/web/components/ui/logo-loop.tsx
+++ b/apps/web/components/ui/logo-loop.tsx
@@ -359,7 +359,6 @@ export const LogoLoop = React.memo<LogoLoopProps>(
                 scaleOnHover && 'overflow-visible group/item'
               )}
               key={key}
-              role="listitem"
             >
               {renderItem(item, key)}
             </li>
@@ -436,7 +435,6 @@ export const LogoLoop = React.memo<LogoLoopProps>(
               scaleOnHover && 'overflow-visible group/item'
             )}
             key={key}
-            role="listitem"
           >
             {inner}
           </li>

--- a/apps/web/components/ui/macbook-scroll.tsx
+++ b/apps/web/components/ui/macbook-scroll.tsx
@@ -1,6 +1,4 @@
 'use client';
-import React, { useEffect, useRef, useState } from 'react';
-import { MotionValue, motion, useScroll, useTransform } from 'motion/react';
 import {
   ChevronDown,
   ChevronLeft,
@@ -19,8 +17,16 @@ import {
   Volume1,
   Volume2,
 } from 'lucide-react';
-import { cn } from '@/lib/utils';
+import {
+  type MotionValue,
+  motion,
+  useScroll,
+  useTransform,
+} from 'motion/react';
 import Image from 'next/image';
+import type React from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { cn } from '@/lib/utils';
 
 export const MacbookScroll = ({
   src,
@@ -619,6 +625,7 @@ export const OptionKey = ({ className }: { className: string }) => {
       viewBox="0 0 32 32"
       className={className}
     >
+      <title>Option key</title>
       <rect
         stroke="currentColor"
         strokeWidth={2}

--- a/apps/web/components/ui/separator.tsx
+++ b/apps/web/components/ui/separator.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import * as React from 'react';
 import * as SeparatorPrimitive from '@radix-ui/react-separator';
+import * as React from 'react';
 
 import { cn } from '@/lib/utils';
 

--- a/apps/web/components/ui/sheet.tsx
+++ b/apps/web/components/ui/sheet.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import * as React from 'react';
 import * as SheetPrimitive from '@radix-ui/react-dialog';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { X } from 'lucide-react';
+import * as React from 'react';
 
 import { cn } from '@/lib/utils';
 

--- a/apps/web/components/ui/sidebar.tsx
+++ b/apps/web/components/ui/sidebar.tsx
@@ -1,12 +1,9 @@
 'use client';
 
-import * as React from 'react';
 import { Slot } from '@radix-ui/react-slot';
-import { VariantProps, cva } from 'class-variance-authority';
+import { cva, type VariantProps } from 'class-variance-authority';
 import { PanelLeft } from 'lucide-react';
-
-import { useIsMobile } from '@/hooks/use-mobile';
-import { cn } from '@/lib/utils';
+import * as React from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Separator } from '@/components/ui/separator';
@@ -24,6 +21,8 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip';
+import { useIsMobile } from '@/hooks/use-mobile';
+import { cn } from '@/lib/utils';
 
 const SIDEBAR_COOKIE_NAME = 'sidebar_state';
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;

--- a/apps/web/components/ui/tooltip.tsx
+++ b/apps/web/components/ui/tooltip.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import * as React from 'react';
 import * as TooltipPrimitive from '@radix-ui/react-tooltip';
+import * as React from 'react';
 
 import { cn } from '@/lib/utils';
 

--- a/apps/web/hooks/use-chat.ts
+++ b/apps/web/hooks/use-chat.ts
@@ -14,7 +14,9 @@ export function useTradeChat(engagementId: string | null) {
   const [messages, setMessages] = useState<TradeMessage[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [otherPartyOnline, setOtherPartyOnline] = useState(false);
-  const [otherPartyLastSeen, setOtherPartyLastSeen] = useState<Date | null>(null);
+  const [otherPartyLastSeen, setOtherPartyLastSeen] = useState<Date | null>(
+    null
+  );
   const [otherPartyTyping, setOtherPartyTyping] = useState(false);
 
   const typingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -86,15 +88,22 @@ export function useTradeChat(engagementId: string | null) {
           );
         })
         .on('presence', { event: 'sync' }, () => {
-          const state = channel.presenceState<{ userId: string; lastSeen: string }>();
+          const state = channel.presenceState<{
+            userId: string;
+            lastSeen: string;
+          }>();
           const others = Object.values(state)
             .flat()
             .filter((p) => p.userId !== user.id);
           setOtherPartyOnline(others.length > 0);
         })
         .on('presence', { event: 'leave' }, (payload) => {
-          const left = (payload.leftPresences as unknown as Array<{ userId: string; lastSeen: string }>)
-            .filter((p) => p.userId !== user.id);
+          const left = (
+            payload.leftPresences as unknown as Array<{
+              userId: string;
+              lastSeen: string;
+            }>
+          ).filter((p) => p.userId !== user.id);
           if (left.length > 0) {
             setOtherPartyLastSeen(new Date());
             setOtherPartyOnline(false);
@@ -102,7 +111,10 @@ export function useTradeChat(engagementId: string | null) {
         })
         .subscribe(async (status) => {
           if (status === 'SUBSCRIBED') {
-            await channel.track({ userId: user.id, lastSeen: new Date().toISOString() });
+            await channel.track({
+              userId: user.id,
+              lastSeen: new Date().toISOString(),
+            });
           }
         });
 
@@ -120,7 +132,14 @@ export function useTradeChat(engagementId: string | null) {
     };
   }, [engagementId]);
 
-  return { chat, messages, isLoading, otherPartyOnline, otherPartyLastSeen, otherPartyTyping };
+  return {
+    chat,
+    messages,
+    isLoading,
+    otherPartyOnline,
+    otherPartyLastSeen,
+    otherPartyTyping,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -263,8 +282,12 @@ export function useMarkAsRead(chatId: string | null) {
 
 export function useUnreadCount(userId: string | null) {
   const [totalUnread, setTotalUnread] = useState(0);
-  const [unreadByChatId, setUnreadByChatId] = useState<Record<string, number>>({});
-  const [unreadByEngagementId, setUnreadByEngagementId] = useState<Record<string, number>>({});
+  const [unreadByChatId, setUnreadByChatId] = useState<Record<string, number>>(
+    {}
+  );
+  const [unreadByEngagementId, setUnreadByEngagementId] = useState<
+    Record<string, number>
+  >({});
 
   const refresh = useCallback(async () => {
     if (!userId) return;

--- a/apps/web/hooks/use-disputed-escrows.ts
+++ b/apps/web/hooks/use-disputed-escrows.ts
@@ -1,8 +1,8 @@
 'use client';
 
 import type { Escrow } from '@pacto-p2p/types';
-import { useGetEscrowsFromIndexerByRole } from '@trustless-work/escrow';
 import { useQuery } from '@tanstack/react-query';
+import { useGetEscrowsFromIndexerByRole } from '@trustless-work/escrow';
 
 /**
  * Fetches all escrows where the platform is the disputeResolver and status=disputed.

--- a/apps/web/hooks/use-escrow-actions.ts
+++ b/apps/web/hooks/use-escrow-actions.ts
@@ -1,16 +1,19 @@
 'use client';
 
-import { useState } from 'react';
-import { useQueryClient } from '@tanstack/react-query';
-import { sileo } from 'sileo';
-import { useInitializeTrade, type DisputeDistribution } from '@/hooks/use-trades';
-import { useEscrowSelection } from '@/hooks/use-escrow-selection';
 import type { Escrow } from '@pacto-p2p/types';
-import { ReportPaymentData } from '@/lib/types/escrow';
-import { TrustlineError } from '@/utils/stellar/TrustlineError';
+import { useQueryClient } from '@tanstack/react-query';
+import { useState } from 'react';
+import { sileo } from 'sileo';
+import { useEscrowSelection } from '@/hooks/use-escrow-selection';
+import {
+  type DisputeDistribution,
+  useInitializeTrade,
+} from '@/hooks/use-trades';
 import { ChatService } from '@/lib/services/chat';
-import { TradesService } from '@/lib/services/trades';
 import { triggerStatsRecompute } from '@/lib/services/stats-trigger';
+import { TradesService } from '@/lib/services/trades';
+import type { ReportPaymentData } from '@/lib/types/escrow';
+import { TrustlineError } from '@/utils/stellar/TrustlineError';
 
 export function useEscrowActions() {
   const [isReportPaymentLoading, setIsReportPaymentLoading] = useState(false);
@@ -133,7 +136,9 @@ export function useEscrowActions() {
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: ['escrows'] }),
         queryClient.invalidateQueries({ queryKey: ['trades'] }),
-        queryClient.invalidateQueries({ queryKey: ['admin', 'disputed-escrows'] }),
+        queryClient.invalidateQueries({
+          queryKey: ['admin', 'disputed-escrows'],
+        }),
       ]);
       selectEscrow({
         ...escrow,
@@ -162,10 +167,18 @@ export function useEscrowActions() {
       // Persist release hash + mark trade as completed in DB
       if (result?.txHash && escrow.engagementId) {
         try {
-          const escrowRecord = await TradesService.getEscrowByEngagementId(escrow.engagementId);
+          const escrowRecord = await TradesService.getEscrowByEngagementId(
+            escrow.engagementId
+          );
           if (escrowRecord?.id) {
-            await TradesService.updateEscrowTransactionHash(escrowRecord.id, 'release', result.txHash);
-            const trade = await TradesService.getTradeByEscrowId(escrow.engagementId);
+            await TradesService.updateEscrowTransactionHash(
+              escrowRecord.id,
+              'release',
+              result.txHash
+            );
+            const trade = await TradesService.getTradeByEscrowId(
+              escrow.engagementId
+            );
             if (trade?.id) {
               await TradesService.updateTrade(trade.id, {
                 status: 'completed',

--- a/apps/web/hooks/use-escrows.ts
+++ b/apps/web/hooks/use-escrows.ts
@@ -10,13 +10,14 @@ import {
 } from '@trustless-work/escrow';
 import { useRouter } from 'next/navigation';
 import { sileo } from 'sileo';
-import { supabase } from '@/lib/supabase';
-import type { CreateEscrowData } from '@/lib/types';
-import { TradesService } from '@/lib/services/trades';
 import { ChatService } from '@/lib/services/chat';
 import { triggerStatsRecompute } from '@/lib/services/stats-trigger';
+import { TradesService } from '@/lib/services/trades';
+import { supabase } from '@/lib/supabase';
+import type { CreateEscrowData } from '@/lib/types';
 import useGlobalAuthenticationStore from '@/store/wallet.store';
 import { useInitializeTrade } from './use-trades';
+
 const MAX_ACTIVE_ESCROWS_PER_BUYER_PER_LISTING = 1;
 
 // Uses buyer UUID (not Stellar address) and queries the trades table
@@ -43,14 +44,21 @@ async function getActiveBuyerTradeCount(
   if (!trades || trades.length === 0) return 0;
 
   // Step 2: check if linked escrows were released on-chain
-  const linkedEscrowIds = trades.map((t) => t.escrow_id).filter(Boolean) as string[];
+  const linkedEscrowIds = trades
+    .map((t) => t.escrow_id)
+    .filter(Boolean) as string[];
 
   // Step 3: also fetch ALL escrows for this buyer+listing by buyer_id+listing_id
   // to handle legacy trades where escrow_id was never stored on the trade row
   const [linkedResult, allResult] = await Promise.all([
     linkedEscrowIds.length > 0
-      ? supabase.from('escrows').select('id, transaction_hashes').in('id', linkedEscrowIds)
-      : Promise.resolve({ data: [] as Array<{ id: string; transaction_hashes: unknown }> }),
+      ? supabase
+          .from('escrows')
+          .select('id, transaction_hashes')
+          .in('id', linkedEscrowIds)
+      : Promise.resolve({
+          data: [] as Array<{ id: string; transaction_hashes: unknown }>,
+        }),
     supabase
       .from('escrows')
       .select('id, transaction_hashes')
@@ -114,7 +122,11 @@ interface UseEscrowsByRoleQueryParams
   validateOnChain?: boolean;
   staleTime?: number;
   refetchInterval?: number | false;
-  context?: 'dashboard-list' | 'detail-page' | 'critical-flow' | 'background-refetch';
+  context?:
+    | 'dashboard-list'
+    | 'detail-page'
+    | 'critical-flow'
+    | 'background-refetch';
 }
 
 interface UseEscrowsBySignerQueryParams
@@ -123,7 +135,11 @@ interface UseEscrowsBySignerQueryParams
   validateOnChain?: boolean;
   staleTime?: number;
   refetchInterval?: number | false;
-  context?: 'dashboard-list' | 'detail-page' | 'critical-flow' | 'background-refetch';
+  context?:
+    | 'dashboard-list'
+    | 'detail-page'
+    | 'critical-flow'
+    | 'background-refetch';
 }
 
 /**
@@ -142,9 +158,8 @@ const handleRateLimitRetry = async (
   ) {
     if (retryCount < RATE_LIMIT_MAX_RETRIES) {
       const delay =
-        RATE_LIMIT_RETRY_DELAY *
-        Math.pow(RATE_LIMIT_BACKOFF_MULTIPLIER, retryCount);
-      await new Promise(resolve => setTimeout(resolve, delay));
+        RATE_LIMIT_RETRY_DELAY * RATE_LIMIT_BACKOFF_MULTIPLIER ** retryCount;
+      await new Promise((resolve) => setTimeout(resolve, delay));
       return true; // Signal retry
     }
   }
@@ -168,7 +183,10 @@ const syncEscrowsWithPlatformRecords = async (
   await Promise.all(
     escrows.map(async (escrow) => {
       const state = states.get(escrow.engagementId);
-      if (state?.status === 'active' && (escrow.flags?.released || escrow.flags?.resolved)) {
+      if (
+        state?.status === 'active' &&
+        (escrow.flags?.released || escrow.flags?.resolved)
+      ) {
         try {
           await TradesService.syncCompletedStatus(escrow.engagementId);
           didSyncCompletions = true;
@@ -245,13 +263,13 @@ export const useEscrowsByRoleQuery = ({
       ? staleTime
       : context === 'dashboard-list' && isActive
         ? STALE_TIME.ACTIVE_ESCROW_POLLING
-      : STALE_TIME[
-          context === 'critical-flow'
-            ? 'CRITICAL_FLOW'
-            : context === 'detail-page'
-              ? 'DETAIL_PAGE'
-              : 'DASHBOARD_LIST'
-        ];
+        : STALE_TIME[
+            context === 'critical-flow'
+              ? 'CRITICAL_FLOW'
+              : context === 'detail-page'
+                ? 'DETAIL_PAGE'
+                : 'DASHBOARD_LIST'
+          ];
 
   const resolvedRefetchInterval =
     refetchInterval !== undefined
@@ -315,7 +333,8 @@ export const useEscrowsByRoleQuery = ({
             throw new Error('Failed to fetch escrows');
           }
 
-          const { escrows: synced, didSyncCompletions } = await syncEscrowsWithPlatformRecords(escrows);
+          const { escrows: synced, didSyncCompletions } =
+            await syncEscrowsWithPlatformRecords(escrows);
           if (didSyncCompletions) {
             queryClient.invalidateQueries({ queryKey: ['trades'] });
           }
@@ -421,13 +440,13 @@ export const useEscrowsBySignerQuery = ({
       ? staleTime
       : context === 'dashboard-list' && isActive
         ? STALE_TIME.ACTIVE_ESCROW_POLLING
-      : STALE_TIME[
-          context === 'critical-flow'
-            ? 'CRITICAL_FLOW'
-            : context === 'detail-page'
-              ? 'DETAIL_PAGE'
-              : 'DASHBOARD_LIST'
-        ];
+        : STALE_TIME[
+            context === 'critical-flow'
+              ? 'CRITICAL_FLOW'
+              : context === 'detail-page'
+                ? 'DETAIL_PAGE'
+                : 'DASHBOARD_LIST'
+          ];
 
   const resolvedRefetchInterval =
     refetchInterval !== undefined
@@ -489,7 +508,8 @@ export const useEscrowsBySignerQuery = ({
             throw new Error('Failed to fetch escrows');
           }
 
-          const { escrows: synced, didSyncCompletions } = await syncEscrowsWithPlatformRecords(escrows);
+          const { escrows: synced, didSyncCompletions } =
+            await syncEscrowsWithPlatformRecords(escrows);
           if (didSyncCompletions) {
             queryClient.invalidateQueries({ queryKey: ['trades'] });
           }
@@ -572,10 +592,18 @@ export function useCreateEscrow(onSuccessCallback?: () => void) {
         const [{ data: buyerUser }, { data: sellerUser }] = await Promise.all([
           buyerUuid
             ? Promise.resolve({ data: { id: buyerUuid } })
-            : supabase.from('users').select('id').eq('stellar_address', escrowData.buyer_id).maybeSingle(),
+            : supabase
+                .from('users')
+                .select('id')
+                .eq('stellar_address', escrowData.buyer_id)
+                .maybeSingle(),
           sellerUuid
             ? Promise.resolve({ data: { id: sellerUuid } })
-            : supabase.from('users').select('id').eq('stellar_address', escrowData.seller_id).maybeSingle(),
+            : supabase
+                .from('users')
+                .select('id')
+                .eq('stellar_address', escrowData.seller_id)
+                .maybeSingle(),
         ]);
         if (!buyerUser) throw new Error('Buyer account not found.');
         if (!sellerUser) throw new Error('Seller account not found.');
@@ -595,12 +623,16 @@ export function useCreateEscrow(onSuccessCallback?: () => void) {
 
       // Rate limit: block if buyer already has an active (non-completed) trade
       // for this listing to prevent griefing with unfunded escrows.
-      const activeTradeCount = await getActiveBuyerTradeCount(buyerUuid, listingId);
+      const activeTradeCount = await getActiveBuyerTradeCount(
+        buyerUuid,
+        listingId
+      );
       if (activeTradeCount >= MAX_ACTIVE_ESCROWS_PER_BUYER_PER_LISTING) {
         throw new Error('You already have an active trade for this listing.');
       }
 
-      const { txHash, engagementId, contractId } = await initializeTrade(escrowData);
+      const { txHash, engagementId, contractId } =
+        await initializeTrade(escrowData);
 
       // 1. Insert into escrows table (include init tx hash if available)
       const { data: escrowRow, error: escrowError } = await supabase
@@ -631,7 +663,8 @@ export function useCreateEscrow(onSuccessCallback?: () => void) {
         token: escrowData.token || escrowData.listing.token,
         token_amount: escrowData.amount,
         fiat_amount: escrowData.fiat_amount,
-        fiat_currency: escrowData.fiat_currency || escrowData.listing.fiat_currency,
+        fiat_currency:
+          escrowData.fiat_currency || escrowData.listing.fiat_currency,
         rate: escrowData.listing.rate,
         payment_method: escrowData.listing.payment_method,
         stellar_transaction_hash: txHash ?? null,
@@ -651,7 +684,10 @@ export function useCreateEscrow(onSuccessCallback?: () => void) {
         .maybeSingle();
 
       if (listingRow) {
-        const newRemaining = Math.max(0, (listingRow.amount_remaining ?? 0) - escrowData.amount);
+        const newRemaining = Math.max(
+          0,
+          (listingRow.amount_remaining ?? 0) - escrowData.amount
+        );
         await supabase
           .from('listings')
           .update({
@@ -894,7 +930,9 @@ export function useReleaseFunds() {
             result.txHash
           );
           // Also update the trade status to completed
-          const trade = await TradesService.getTradeByEscrowId(escrow.engagementId);
+          const trade = await TradesService.getTradeByEscrowId(
+            escrow.engagementId
+          );
           if (trade?.id) {
             await TradesService.updateTrade(trade.id, {
               status: 'completed',

--- a/apps/web/hooks/use-listings.ts
+++ b/apps/web/hooks/use-listings.ts
@@ -1,10 +1,10 @@
 'use client';
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { mapDbListingToMarketplace } from '@/lib/marketplace-utils';
 import { ListingsService } from '@/lib/services/listings';
 import type { CreateListingData } from '@/lib/types';
 import type { DbListing } from '@/lib/types/db';
-import { mapDbListingToMarketplace } from '@/lib/marketplace-utils';
 import type { MarketplaceListing } from '@/lib/types/marketplace';
 
 export function useListings(filters?: {

--- a/apps/web/hooks/use-pacto-escrow-ids.ts
+++ b/apps/web/hooks/use-pacto-escrow-ids.ts
@@ -16,7 +16,9 @@ export function usePactoEscrowIds(engagementIds: string[]): Set<string> {
         .from('escrows')
         .select('engagement_id')
         .in('engagement_id', engagementIds);
-      return (data ?? []).map((r) => r.engagement_id).filter(Boolean) as string[];
+      return (data ?? [])
+        .map((r) => r.engagement_id)
+        .filter(Boolean) as string[];
     },
     enabled: engagementIds.length > 0,
     staleTime: 1000 * 60 * 5,

--- a/apps/web/hooks/use-pending-actions.ts
+++ b/apps/web/hooks/use-pending-actions.ts
@@ -1,10 +1,10 @@
 'use client';
 
-import { useMemo } from 'react';
 import type { Escrow } from '@pacto-p2p/types';
+import { useMemo } from 'react';
+import useGlobalAuthenticationStore from '@/store/wallet.store';
 import { useEscrowsByRoleQuery } from './use-escrows';
 import { usePactoEscrowIds } from './use-pacto-escrow-ids';
-import useGlobalAuthenticationStore from '@/store/wallet.store';
 
 export function usePendingActions() {
   const { address } = useGlobalAuthenticationStore();
@@ -32,10 +32,17 @@ export function usePendingActions() {
   );
   const pactoIds = usePactoEscrowIds(allEngagementIds);
 
-  const pactoSellerEscrows = sellerEscrows.filter((e) => pactoIds.has(e.engagementId));
-  const pactoBuyerEscrows = buyerEscrows.filter((e) => pactoIds.has(e.engagementId));
+  const pactoSellerEscrows = sellerEscrows.filter((e) =>
+    pactoIds.has(e.engagementId)
+  );
+  const pactoBuyerEscrows = buyerEscrows.filter((e) =>
+    pactoIds.has(e.engagementId)
+  );
 
-  const pendingCount = countPendingActions(pactoSellerEscrows, pactoBuyerEscrows);
+  const pendingCount = countPendingActions(
+    pactoSellerEscrows,
+    pactoBuyerEscrows
+  );
 
   return { pendingCount };
 }

--- a/apps/web/hooks/use-trades.ts
+++ b/apps/web/hooks/use-trades.ts
@@ -16,18 +16,18 @@ import {
   useSendTransaction,
   useStartDispute,
 } from '@trustless-work/escrow';
+import {
+  canCancel,
+  getEscrowCancellationGraceHours,
+  getEscrowRole,
+} from '@/lib/escrow-utils';
+import { TradesService } from '@/lib/services/trades';
 import type { CreateEscrowData } from '@/lib/types';
 import { signTransaction } from '@/lib/wallet';
 import useGlobalAuthenticationStore from '@/store/wallet.store';
 import { getTrustline, getTrustlineName } from '@/utils/getTrustline';
 import { hasTrustline } from '@/utils/stellar/hasTrustline';
 import { TrustlineError } from '@/utils/stellar/TrustlineError';
-import {
-  canCancel,
-  getEscrowRole,
-  getEscrowCancellationGraceHours,
-} from '@/lib/escrow-utils';
-import { TradesService } from '@/lib/services/trades';
 
 export interface DisputeDistribution {
   address: string;
@@ -119,7 +119,9 @@ export const useInitializeTrade = () => {
     const finalPayload = {
       signer: address,
       engagementId,
-      description: payload.listing.description || `${payload.listing.token}/${payload.listing.fiat_currency} P2P trade`,
+      description:
+        payload.listing.description ||
+        `${payload.listing.token}/${payload.listing.fiat_currency} P2P trade`,
       trustline: {
         address: trustline.address, // Issuer address (G...)
         symbol: trustline.symbol, // Token symbol (e.g., "USDC")
@@ -140,21 +142,28 @@ export const useInitializeTrade = () => {
       amount: payload.amount,
       milestones: [
         {
-          description: payload.listing.description || `${payload.listing.token}/${payload.listing.fiat_currency} P2P trade`,
+          description:
+            payload.listing.description ||
+            `${payload.listing.token}/${payload.listing.fiat_currency} P2P trade`,
         },
       ],
     };
 
     let deployResult: InitializeSingleReleaseEscrowResponse;
     try {
-      deployResult = await deployEscrow(
+      deployResult = (await deployEscrow(
         finalPayload,
         'single-release'
-      ) as InitializeSingleReleaseEscrowResponse;
+      )) as InitializeSingleReleaseEscrowResponse;
     } catch (err: unknown) {
-      const axiosErr = err as { response?: { data?: { message?: string } }; message?: string };
+      const axiosErr = err as {
+        response?: { data?: { message?: string } };
+        message?: string;
+      };
       const apiMessage = axiosErr?.response?.data?.message;
-      throw new Error(apiMessage || axiosErr?.message || 'Failed to deploy escrow');
+      throw new Error(
+        apiMessage || axiosErr?.message || 'Failed to deploy escrow'
+      );
     }
     const { unsignedTransaction, contractId } = deployResult;
 
@@ -177,10 +186,16 @@ export const useInitializeTrade = () => {
     try {
       response = await sendTransaction(signedTxXdr);
     } catch (err: unknown) {
-      const axiosErr = err as { response?: { data?: { message?: string; details?: unknown } }; message?: string };
+      const axiosErr = err as {
+        response?: { data?: { message?: string; details?: unknown } };
+        message?: string;
+      };
       const apiMsg = axiosErr?.response?.data?.message;
       const details = axiosErr?.response?.data?.details;
-      console.error('[sendTransaction] error:', axiosErr?.response?.data ?? err);
+      console.error(
+        '[sendTransaction] error:',
+        axiosErr?.response?.data ?? err
+      );
       throw new Error(
         details
           ? `Transaction failed: ${JSON.stringify(details)}`
@@ -282,11 +297,7 @@ export const useInitializeTrade = () => {
           escrowAssetCode,
           escrowAssetIssuer
         ),
-        hasTrustline(
-          escrow.roles.receiver,
-          escrowAssetCode,
-          escrowAssetIssuer
-        ),
+        hasTrustline(escrow.roles.receiver, escrowAssetCode, escrowAssetIssuer),
       ]);
 
       if (!sellerHasTrustline) {
@@ -459,13 +470,21 @@ export const useInitializeTrade = () => {
 
     let approveMilestoneResult: { unsignedTransaction?: string };
     try {
-      approveMilestoneResult = await approveMilestone(finalPayload, 'single-release');
+      approveMilestoneResult = await approveMilestone(
+        finalPayload,
+        'single-release'
+      );
     } catch (err: unknown) {
-      const axiosErr = err as { response?: { data?: { message?: string; details?: unknown } }; message?: string };
+      const axiosErr = err as {
+        response?: { data?: { message?: string; details?: unknown } };
+        message?: string;
+      };
       const apiMsg = axiosErr?.response?.data?.message;
       const details = axiosErr?.response?.data?.details;
       throw new Error(
-        details ? `Approve milestone failed: ${JSON.stringify(details)}` : apiMsg || axiosErr?.message || 'Failed to approve milestone'
+        details
+          ? `Approve milestone failed: ${JSON.stringify(details)}`
+          : apiMsg || axiosErr?.message || 'Failed to approve milestone'
       );
     }
 

--- a/apps/web/hooks/use-wallet.ts
+++ b/apps/web/hooks/use-wallet.ts
@@ -1,11 +1,11 @@
-import { useEffect } from 'react';
 import { StellarWalletsKit } from '@creit-tech/stellar-wallets-kit/sdk';
 import { KitEventType } from '@creit-tech/stellar-wallets-kit/types';
+import { useEffect } from 'react';
 import { toast } from 'sonner';
 import {
+  getInitializationError,
   initializeWalletKit,
   isWalletKitInitialized,
-  getInitializationError,
 } from '@/lib/wallet';
 import useGlobalAuthenticationStore from '@/store/wallet.store';
 

--- a/apps/web/hooks/useMerchant.ts
+++ b/apps/web/hooks/useMerchant.ts
@@ -2,9 +2,9 @@
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { sileo } from 'sileo';
+import { useAuth } from '@/hooks/use-auth';
 import { merchantAdapter } from '@/lib/adapters';
 import { applyAsMerchant } from '@/lib/services/merchants';
-import { useAuth } from '@/hooks/use-auth';
 import type {
   Merchant,
   MerchantBadge,

--- a/apps/web/lib/adapters/merchant.supabase.ts
+++ b/apps/web/lib/adapters/merchant.supabase.ts
@@ -1,11 +1,11 @@
-import { supabase } from '@/lib/supabase';
 import type { MerchantAdapter } from '@/lib/adapters/merchant';
+import { supabase } from '@/lib/supabase';
 import type {
   Merchant,
-  MerchantVerificationStatus,
   MerchantBadge,
   MerchantKpis,
   MerchantListing,
+  MerchantVerificationStatus,
   SpeedBucket,
   VolumePoint,
 } from '@/lib/types/merchant';
@@ -125,7 +125,6 @@ async function ensureUserProfile(userId: string): Promise<void> {
 }
 
 export const merchantSupabaseAdapter: MerchantAdapter = {
-
   async listPublicMerchants(): Promise<Merchant[]> {
     const { data, error } = await supabase
       .from('merchants')
@@ -157,8 +156,7 @@ export const merchantSupabaseAdapter: MerchantAdapter = {
     return data ? mapRowToMerchant(data) : null;
   },
 
-  
-async getBadges(merchantId: string): Promise<MerchantBadge[]> {
+  async getBadges(merchantId: string): Promise<MerchantBadge[]> {
     const kpis = await this.getKpis(merchantId);
     const badges: MerchantBadge[] = [];
     const now = new Date().toISOString();
@@ -243,24 +241,35 @@ async getBadges(merchantId: string): Promise<MerchantBadge[]> {
     const thirtyDaysAgo = new Date();
     thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
 
-    const [totalRes, completedRes, disputedRes, volumeRes, speedRes] = await Promise.all([
-      supabase.from('trades').select('id', { count: 'exact', head: true })
-        .eq('seller_id', merchant.user_id),
-      supabase.from('trades').select('id', { count: 'exact', head: true })
-        .eq('status', 'completed')
-        .eq('seller_id', merchant.user_id),
-      supabase.from('trades').select('id', { count: 'exact', head: true })
-        .eq('status', 'disputed')
-        .eq('seller_id', merchant.user_id),
-      supabase.from('trades').select('fiat_amount')
-        .eq('status', 'completed')
-        .eq('seller_id', merchant.user_id)
-        .gte('created_at', thirtyDaysAgo.toISOString()),
-      supabase.from('trades').select('created_at, completed_at')
-        .eq('status', 'completed')
-        .eq('seller_id', merchant.user_id)
-        .not('completed_at', 'is', null),
-    ]);
+    const [totalRes, completedRes, disputedRes, volumeRes, speedRes] =
+      await Promise.all([
+        supabase
+          .from('trades')
+          .select('id', { count: 'exact', head: true })
+          .eq('seller_id', merchant.user_id),
+        supabase
+          .from('trades')
+          .select('id', { count: 'exact', head: true })
+          .eq('status', 'completed')
+          .eq('seller_id', merchant.user_id),
+        supabase
+          .from('trades')
+          .select('id', { count: 'exact', head: true })
+          .eq('status', 'disputed')
+          .eq('seller_id', merchant.user_id),
+        supabase
+          .from('trades')
+          .select('fiat_amount')
+          .eq('status', 'completed')
+          .eq('seller_id', merchant.user_id)
+          .gte('created_at', thirtyDaysAgo.toISOString()),
+        supabase
+          .from('trades')
+          .select('created_at, completed_at')
+          .eq('status', 'completed')
+          .eq('seller_id', merchant.user_id)
+          .not('completed_at', 'is', null),
+      ]);
 
     if (totalRes.error) throw new Error(totalRes.error.message);
 
@@ -268,17 +277,24 @@ async getBadges(merchantId: string): Promise<MerchantBadge[]> {
     const completed = completedRes.count ?? 0;
     const disputed = disputedRes.count ?? 0;
     const volume_30d = (volumeRes.data ?? []).reduce(
-      (acc: number, curr: { fiat_amount: string | number }) => acc + Number(curr.fiat_amount),
+      (acc: number, curr: { fiat_amount: string | number }) =>
+        acc + Number(curr.fiat_amount),
       0
     );
 
     let median_release_minutes: number | null = null;
     if (speedRes.data && speedRes.data.length > 0) {
       const diffs = speedRes.data
-        .map(r => (new Date(r.completed_at!).getTime() - new Date(r.created_at).getTime()) / 60000)
+        .map(
+          (r) =>
+            (new Date(r.completed_at!).getTime() -
+              new Date(r.created_at).getTime()) /
+            60000
+        )
         .sort((a, b) => a - b);
       const mid = Math.floor(diffs.length / 2);
-      median_release_minutes = diffs.length % 2 !== 0 ? diffs[mid] : (diffs[mid - 1] + diffs[mid]) / 2;
+      median_release_minutes =
+        diffs.length % 2 !== 0 ? diffs[mid] : (diffs[mid - 1] + diffs[mid]) / 2;
     }
 
     return {
@@ -310,12 +326,15 @@ async getBadges(merchantId: string): Promise<MerchantBadge[]> {
     if (error || !data) return [];
 
     const seriesMap = new Map<string, number>();
-    data.forEach(row => {
+    data.forEach((row) => {
       const date = row.created_at.split('T')[0];
       seriesMap.set(date, (seriesMap.get(date) ?? 0) + Number(row.fiat_amount));
     });
 
-    return Array.from(seriesMap.entries()).map(([date, volume]) => ({ d: date, volume }));
+    return Array.from(seriesMap.entries()).map(([date, volume]) => ({
+      d: date,
+      volume,
+    }));
   },
 
   async getSpeedHistogram(merchantId: string): Promise<SpeedBucket[]> {
@@ -334,16 +353,28 @@ async getBadges(merchantId: string): Promise<MerchantBadge[]> {
       .not('completed_at', 'is', null);
 
     if (!data) return [];
-    const buckets: Record<string, number> = { '< 5m': 0, '5-15m': 0, '15-30m': 0, '30-60m': 0, '> 60m': 0 };
-    data.forEach(r => {
-      const mins = (new Date(r.completed_at!).getTime() - new Date(r.created_at).getTime()) / 60000;
+    const buckets: Record<string, number> = {
+      '< 5m': 0,
+      '5-15m': 0,
+      '15-30m': 0,
+      '30-60m': 0,
+      '> 60m': 0,
+    };
+    data.forEach((r) => {
+      const mins =
+        (new Date(r.completed_at!).getTime() -
+          new Date(r.created_at).getTime()) /
+        60000;
       if (mins < 5) buckets['< 5m']++;
       else if (mins < 15) buckets['5-15m']++;
       else if (mins < 30) buckets['15-30m']++;
       else if (mins < 60) buckets['30-60m']++;
       else buckets['> 60m']++;
     });
-    return Object.entries(buckets).map(([bucketLabel, count]) => ({ bucketLabel, count }));
+    return Object.entries(buckets).map(([bucketLabel, count]) => ({
+      bucketLabel,
+      count,
+    }));
   },
 
   async getActiveListings(merchantId: string): Promise<MerchantListing[]> {
@@ -355,32 +386,34 @@ async getBadges(merchantId: string): Promise<MerchantBadge[]> {
       .order('created_at', { ascending: false });
     if (error) throw new Error(error.message);
     const rows = data ?? [];
-    return rows.map((r: {
-      id: string;
-      type: string;
-      token: string;
-      rate: string | number;
-      fiat_currency: string;
-      amount: string | number;
-      min_amount: string | number | null;
-      max_amount: string | number | null;
-      description: string | null;
-      status: string;
-      created_at: string;
-    }) => ({
-      id: r.id,
-      side: r.type as 'buy' | 'sell',
-      asset_code: r.token,
-      price_rate: Number(r.rate),
-      quote_currency: r.fiat_currency,
-      amount: Number(r.amount),
-      min_amount: r.min_amount ? Number(r.min_amount) : undefined,
-      max_amount: r.max_amount ? Number(r.max_amount) : undefined,
-      description: r.description ?? undefined,
-      status: r.status as MerchantListing['status'],
-      created_at: r.created_at,
-      payment_methods: [],
-    })) as MerchantListing[];
+    return rows.map(
+      (r: {
+        id: string;
+        type: string;
+        token: string;
+        rate: string | number;
+        fiat_currency: string;
+        amount: string | number;
+        min_amount: string | number | null;
+        max_amount: string | number | null;
+        description: string | null;
+        status: string;
+        created_at: string;
+      }) => ({
+        id: r.id,
+        side: r.type as 'buy' | 'sell',
+        asset_code: r.token,
+        price_rate: Number(r.rate),
+        quote_currency: r.fiat_currency,
+        amount: Number(r.amount),
+        min_amount: r.min_amount ? Number(r.min_amount) : undefined,
+        max_amount: r.max_amount ? Number(r.max_amount) : undefined,
+        description: r.description ?? undefined,
+        status: r.status as MerchantListing['status'],
+        created_at: r.created_at,
+        payment_methods: [],
+      })
+    ) as MerchantListing[];
   },
 
   async getMyMerchant(): Promise<Merchant | null> {
@@ -542,32 +575,34 @@ async getBadges(merchantId: string): Promise<MerchantBadge[]> {
       .order('created_at', { ascending: false });
     if (error) throw new Error(error.message);
 
-    return (data ?? []).map((r: {
-      id: string;
-      type: string;
-      token: string;
-      rate: string | number;
-      fiat_currency: string;
-      amount: string | number;
-      min_amount: string | number | null;
-      max_amount: string | number | null;
-      description: string | null;
-      status: string;
-      created_at: string;
-    }) => ({
-      id: r.id,
-      side: r.type as 'buy' | 'sell',
-      asset_code: r.token,
-      price_rate: Number(r.rate),
-      quote_currency: r.fiat_currency,
-      amount: Number(r.amount),
-      min_amount: r.min_amount ? Number(r.min_amount) : undefined,
-      max_amount: r.max_amount ? Number(r.max_amount) : undefined,
-      description: r.description ?? undefined,
-      status: r.status as MerchantListing['status'],
-      created_at: r.created_at,
-      payment_methods: [],
-    })) as MerchantListing[];
+    return (data ?? []).map(
+      (r: {
+        id: string;
+        type: string;
+        token: string;
+        rate: string | number;
+        fiat_currency: string;
+        amount: string | number;
+        min_amount: string | number | null;
+        max_amount: string | number | null;
+        description: string | null;
+        status: string;
+        created_at: string;
+      }) => ({
+        id: r.id,
+        side: r.type as 'buy' | 'sell',
+        asset_code: r.token,
+        price_rate: Number(r.rate),
+        quote_currency: r.fiat_currency,
+        amount: Number(r.amount),
+        min_amount: r.min_amount ? Number(r.min_amount) : undefined,
+        max_amount: r.max_amount ? Number(r.max_amount) : undefined,
+        description: r.description ?? undefined,
+        status: r.status as MerchantListing['status'],
+        created_at: r.created_at,
+        payment_methods: [],
+      })
+    ) as MerchantListing[];
   },
 };
 

--- a/apps/web/lib/escrow-utils.ts
+++ b/apps/web/lib/escrow-utils.ts
@@ -1,4 +1,4 @@
-import { Escrow } from '@/lib/types/escrow';
+import type { Escrow } from '@/lib/types/escrow';
 
 const DEFAULT_ESCROW_CANCELLATION_GRACE_HOURS = 24;
 
@@ -100,7 +100,11 @@ export function canCancel(
   userRole: 'buyer' | 'seller'
 ): boolean {
   if (userRole !== 'buyer') return false;
-  if (escrow.flags?.disputed || escrow.flags?.resolved || escrow.flags?.released) {
+  if (
+    escrow.flags?.disputed ||
+    escrow.flags?.resolved ||
+    escrow.flags?.released
+  ) {
     return false;
   }
   if (escrow.balance !== 0) return false;

--- a/apps/web/lib/marketplace-utils.ts
+++ b/apps/web/lib/marketplace-utils.ts
@@ -1,9 +1,9 @@
-import type {
-  MarketplaceListing,
-  ListingFilters,
-} from '@/lib/types/marketplace';
-import type { DbListing } from '@/lib/types/db';
 import type { User } from '@/lib/types';
+import type { DbListing } from '@/lib/types/db';
+import type {
+  ListingFilters,
+  MarketplaceListing,
+} from '@/lib/types/marketplace';
 
 export function filterListings(
   listings: MarketplaceListing[],
@@ -36,13 +36,17 @@ export function getMarketStats(listings: MarketplaceListing[]) {
   const ms24h = 24 * 60 * 60 * 1000;
 
   // Split listings by age
-  const thisWeek = listings.filter((l) => now - new Date(l.created).getTime() < ms7d);
+  const thisWeek = listings.filter(
+    (l) => now - new Date(l.created).getTime() < ms7d
+  );
   const lastWeek = listings.filter((l) => {
     const age = now - new Date(l.created).getTime();
     return age >= ms7d && age < ms7d * 2;
   });
 
-  const last24h = listings.filter((l) => now - new Date(l.created).getTime() < ms24h);
+  const last24h = listings.filter(
+    (l) => now - new Date(l.created).getTime() < ms24h
+  );
   const prev24h = listings.filter((l) => {
     const age = now - new Date(l.created).getTime();
     return age >= ms24h && age < ms24h * 2;
@@ -55,7 +59,8 @@ export function getMarketStats(listings: MarketplaceListing[]) {
   const avgCurrent = listings.length > 0 ? totalValue / listings.length : 0;
   const avgLastWeek =
     lastWeek.length > 0
-      ? lastWeek.reduce((sum, l) => sum + l.amount * l.rate, 0) / lastWeek.length
+      ? lastWeek.reduce((sum, l) => sum + l.amount * l.rate, 0) /
+        lastWeek.length
       : 0;
 
   return {
@@ -80,7 +85,11 @@ export function mapDbListingToMarketplace(
     rate: Number(listing.rate),
     fiatCurrency: listing.fiat_currency,
     paymentMethod: listing.payment_method,
-    seller: listing.seller_address || user?.stellar_address || user?.email || listing.user_id,
+    seller:
+      listing.seller_address ||
+      user?.stellar_address ||
+      user?.email ||
+      listing.user_id,
     buyer: '',
     reputation: user?.reputation_score ?? 0,
     trades: user?.total_trades ?? 0,
@@ -89,7 +98,10 @@ export function mapDbListingToMarketplace(
     description: listing.description || '',
     avatarUrl: user?.avatar_url,
     fullName: user?.full_name,
-    amountRemaining: listing.amount_remaining != null ? Number(listing.amount_remaining) : Number(listing.amount),
+    amountRemaining:
+      listing.amount_remaining != null
+        ? Number(listing.amount_remaining)
+        : Number(listing.amount),
     creatorUserId: listing.user_id,
   };
 }
@@ -121,7 +133,9 @@ export function toCreateListingData(input: UIListingFormInput) {
 
   const totalFiat = amount * rate;
   const minAmount = input.minAmount ? Number.parseFloat(input.minAmount) : 0;
-  const maxAmount = input.maxAmount ? Number.parseFloat(input.maxAmount) : totalFiat;
+  const maxAmount = input.maxAmount
+    ? Number.parseFloat(input.maxAmount)
+    : totalFiat;
 
   return {
     type: input.type,

--- a/apps/web/lib/services/audit.ts
+++ b/apps/web/lib/services/audit.ts
@@ -1,5 +1,9 @@
 import { createAdminClient } from '@/lib/supabase';
-import type { AuditLogEntry, AuditAction, AuditTargetType } from '@/lib/types/audit';
+import type {
+  AuditAction,
+  AuditLogEntry,
+  AuditTargetType,
+} from '@/lib/types/audit';
 
 export class AuditService {
   /**
@@ -24,17 +28,15 @@ export class AuditService {
   }): Promise<void> {
     const supabase = createAdminClient();
 
-    const { error } = await supabase
-      .from('admin_audit_logs')
-      .insert({
-        admin_user_id: adminUserId,
-        action,
-        target_type: targetType,
-        target_id: targetId || null,
-        metadata,
-        ip_address: ipAddress,
-        user_agent: userAgent,
-      });
+    const { error } = await supabase.from('admin_audit_logs').insert({
+      admin_user_id: adminUserId,
+      action,
+      target_type: targetType,
+      target_id: targetId || null,
+      metadata,
+      ip_address: ipAddress,
+      user_agent: userAgent,
+    });
 
     if (error) {
       console.error('Failed to log admin action:', error);

--- a/apps/web/lib/services/auth.ts
+++ b/apps/web/lib/services/auth.ts
@@ -74,7 +74,9 @@ export class AuthService {
 
     // Profile missing — create it once from the current session.
     // (Users created before the handle_new_user trigger won't have a public.users row.)
-    const { data: { session } } = await supabase.auth.getSession();
+    const {
+      data: { session },
+    } = await supabase.auth.getSession();
     if (!session?.user || session.user.id !== userId) return null;
 
     // Only auto-create when we are looking up our own profile
@@ -94,7 +96,9 @@ export class AuthService {
       .eq('id', userId)
       .maybeSingle();
 
-    return created ? normalizeUserFromDb(created as Record<string, unknown>) : null;
+    return created
+      ? normalizeUserFromDb(created as Record<string, unknown>)
+      : null;
   }
 
   static async getUserByWallet(stellarAddress: string): Promise<User | null> {
@@ -141,13 +145,13 @@ export class AuthService {
 
   static async linkWalletToUser(userId: string, stellarAddress: string) {
     // Check if wallet is already linked to another user
-    const existingUser = await this.getUserByWallet(stellarAddress);
+    const existingUser = await AuthService.getUserByWallet(stellarAddress);
     if (existingUser && existingUser.id !== userId) {
       throw new Error('This wallet is already linked to another account');
     }
 
     // Update user profile with wallet address
-    return this.updateUserProfile(userId, {
+    return AuthService.updateUserProfile(userId, {
       stellar_address: stellarAddress,
     });
   }

--- a/apps/web/lib/services/chat.ts
+++ b/apps/web/lib/services/chat.ts
@@ -13,8 +13,7 @@ const SYSTEM_MESSAGES: Record<
     '📤 Buyer has reported payment. Awaiting seller confirmation.',
   payment_confirmed: () =>
     '✅ Seller confirmed payment receipt. Releasing funds…',
-  funds_released: () =>
-    '🎉 Trade complete. Funds have been released to buyer.',
+  funds_released: () => '🎉 Trade complete. Funds have been released to buyer.',
   dispute_raised: () =>
     '⚠️ A dispute has been raised. Platform support will review this trade.',
 };

--- a/apps/web/lib/services/listings.ts
+++ b/apps/web/lib/services/listings.ts
@@ -1,6 +1,6 @@
+import { supabase } from '@/lib/supabase';
 import type { CreateListingData } from '@/lib/types';
 import type { DbListing } from '@/lib/types/db';
-import { supabase } from '@/lib/supabase';
 
 // biome-ignore lint/complexity/noStaticOnlyClass: <explanation>
 export class ListingsService {

--- a/apps/web/lib/services/trades.ts
+++ b/apps/web/lib/services/trades.ts
@@ -1,6 +1,6 @@
+import type { Escrow } from '@pacto-p2p/types';
 import { supabase } from '@/lib/supabase';
 import type { DashboardListing } from '@/lib/types';
-import type { Escrow } from '@pacto-p2p/types';
 import { getTrustlineName } from '@/utils/getTrustline';
 
 export interface DbTrade {
@@ -109,7 +109,9 @@ export class TradesService {
 
     const { data, error } = await supabase
       .from('escrows')
-      .select('id, engagement_id, contract_id, created_at, cancelled_at, status')
+      .select(
+        'id, engagement_id, contract_id, created_at, cancelled_at, status'
+      )
       .in('engagement_id', engagementIds);
 
     if (error) throw new Error(error.message);
@@ -135,9 +137,10 @@ export class TradesService {
     }
 
     const engagementIds = escrows.map((escrow) => escrow.engagementId);
-    const existingStates = await this.getEscrowStatesByEngagementIds(engagementIds);
+    const existingStates =
+      await TradesService.getEscrowStatesByEngagementIds(engagementIds);
     const orphanedEscrows = escrows.filter(
-      escrow => !existingStates.has(escrow.engagementId)
+      (escrow) => !existingStates.has(escrow.engagementId)
     );
 
     if (orphanedEscrows.length === 0) {
@@ -147,7 +150,7 @@ export class TradesService {
     const listingIds = Array.from(
       new Set(
         orphanedEscrows
-          .map(escrow => inferListingIdFromEngagementId(escrow.engagementId))
+          .map((escrow) => inferListingIdFromEngagementId(escrow.engagementId))
           .filter((value): value is string => Boolean(value))
       )
     );
@@ -160,21 +163,23 @@ export class TradesService {
       )
     );
 
-    const [{ data: listingRows, error: listingError }, { data: userRows, error: userError }] =
-      await Promise.all([
-        listingIds.length > 0
-          ? supabase
-              .from('listings')
-              .select('id, rate, fiat_currency, payment_method')
-              .in('id', listingIds)
-          : Promise.resolve({ data: [], error: null }),
-        stellarAddresses.length > 0
-          ? supabase
-              .from('users')
-              .select('id, stellar_address')
-              .in('stellar_address', stellarAddresses)
-          : Promise.resolve({ data: [], error: null }),
-      ]);
+    const [
+      { data: listingRows, error: listingError },
+      { data: userRows, error: userError },
+    ] = await Promise.all([
+      listingIds.length > 0
+        ? supabase
+            .from('listings')
+            .select('id, rate, fiat_currency, payment_method')
+            .in('id', listingIds)
+        : Promise.resolve({ data: [], error: null }),
+      stellarAddresses.length > 0
+        ? supabase
+            .from('users')
+            .select('id, stellar_address')
+            .in('stellar_address', stellarAddresses)
+        : Promise.resolve({ data: [], error: null }),
+    ]);
 
     if (listingError) throw new Error(listingError.message);
     if (userError) throw new Error(userError.message);
@@ -196,17 +201,23 @@ export class TradesService {
       const seller = usersByAddress.get(escrow.roles.approver);
 
       if (!listing || !buyer || !seller) {
-        console.warn('Skipping orphaned escrow recovery due to missing platform data', {
-          engagementId: escrow.engagementId,
-          listingId,
-          hasListing: Boolean(listing),
-          hasBuyer: Boolean(buyer),
-          hasSeller: Boolean(seller),
-        });
+        console.warn(
+          'Skipping orphaned escrow recovery due to missing platform data',
+          {
+            engagementId: escrow.engagementId,
+            listingId,
+            hasListing: Boolean(listing),
+            hasBuyer: Boolean(buyer),
+            hasSeller: Boolean(seller),
+          }
+        );
         continue;
       }
 
-      const fiatAmount = calculateFiatAmount(Number(escrow.amount), Number(listing.rate));
+      const fiatAmount = calculateFiatAmount(
+        Number(escrow.amount),
+        Number(listing.rate)
+      );
       const token = getTrustlineName(escrow.trustline.address);
 
       const { data: escrowRow, error: escrowError } = await supabase
@@ -243,19 +254,21 @@ export class TradesService {
       }
 
       if (!existingTrade) {
-        const { error: tradeInsertError } = await supabase.from('trades').insert({
-          escrow_id: escrowRow.id,
-          listing_id: listing.id,
-          buyer_id: buyer.id,
-          seller_id: seller.id,
-          token,
-          token_amount: escrow.amount,
-          fiat_amount: fiatAmount,
-          fiat_currency: listing.fiat_currency,
-          rate: listing.rate,
-          payment_method: listing.payment_method,
-          status: 'active',
-        });
+        const { error: tradeInsertError } = await supabase
+          .from('trades')
+          .insert({
+            escrow_id: escrowRow.id,
+            listing_id: listing.id,
+            buyer_id: buyer.id,
+            seller_id: seller.id,
+            token,
+            token_amount: escrow.amount,
+            fiat_amount: fiatAmount,
+            fiat_currency: listing.fiat_currency,
+            rate: listing.rate,
+            payment_method: listing.payment_method,
+            status: 'active',
+          });
 
         if (tradeInsertError) {
           throw new Error(tradeInsertError.message);
@@ -293,7 +306,7 @@ export class TradesService {
   }
 
   static async cancelUnfundedEscrow(engagementId: string): Promise<void> {
-    const escrow = await this.getEscrowByEngagementId(engagementId);
+    const escrow = await TradesService.getEscrowByEngagementId(engagementId);
 
     if (!escrow?.id) {
       throw new Error('Escrow record not found in Supabase.');
@@ -310,9 +323,9 @@ export class TradesService {
 
     if (escrowUpdateError) throw new Error(escrowUpdateError.message);
 
-    const trade = await this.getTradeByEscrowId(engagementId);
+    const trade = await TradesService.getTradeByEscrowId(engagementId);
     if (trade?.id) {
-      await this.updateTrade(trade.id, {
+      await TradesService.updateTrade(trade.id, {
         status: 'cancelled',
         completed_at: cancelledAt,
       });
@@ -336,7 +349,8 @@ export class TradesService {
 
     if (fetchError) throw new Error(fetchError.message);
 
-    const currentHashes = (escrow?.transaction_hashes as EscrowTransactionHashes) ?? {};
+    const currentHashes =
+      (escrow?.transaction_hashes as EscrowTransactionHashes) ?? {};
     const updatedHashes = { ...currentHashes, [action]: txHash };
 
     // Update the escrow with new transaction hash
@@ -370,7 +384,9 @@ export class TradesService {
   /**
    * Gets a trade by engagement ID (via escrow lookup)
    */
-  static async getTradeByEscrowId(engagementId: string): Promise<DbTrade | null> {
+  static async getTradeByEscrowId(
+    engagementId: string
+  ): Promise<DbTrade | null> {
     const { data: escrow, error: escrowError } = await supabase
       .from('escrows')
       .select('id')

--- a/apps/web/lib/types/audit.ts
+++ b/apps/web/lib/types/audit.ts
@@ -15,15 +15,15 @@ export interface AuditLogEntry {
   };
 }
 
-export type AuditAction = 
+export type AuditAction =
   | 'merchant_approved'
-  | 'merchant_rejected' 
+  | 'merchant_rejected'
   | 'merchant_revoked'
   | 'token_minted'
   | 'token_burned'
   | 'dispute_resolved';
 
-export type AuditTargetType = 
+export type AuditTargetType =
   | 'merchant'
   | 'token_operation'
   | 'escrow'

--- a/apps/web/lib/utils/require-admin.ts
+++ b/apps/web/lib/utils/require-admin.ts
@@ -1,5 +1,5 @@
-import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
 import { createAdminClient } from '@/lib/supabase';
 
 /**
@@ -9,7 +9,9 @@ import { createAdminClient } from '@/lib/supabase';
  */
 export async function requireAdmin(
   request: NextRequest
-): Promise<{ userId: string; ipAddress?: string; userAgent?: string } | NextResponse> {
+): Promise<
+  { userId: string; ipAddress?: string; userAgent?: string } | NextResponse
+> {
   const authHeader = request.headers.get('Authorization');
   const token = authHeader?.replace('Bearer ', '');
 
@@ -42,12 +44,12 @@ export async function requireAdmin(
     request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
     request.headers.get('x-real-ip') ||
     undefined;
-  
+
   const userAgent = request.headers.get('user-agent') || undefined;
 
-  return { 
+  return {
     userId: user.id,
     ipAddress,
-    userAgent
+    userAgent,
   };
 }

--- a/apps/web/lib/wallet.ts
+++ b/apps/web/lib/wallet.ts
@@ -1,5 +1,5 @@
-import { StellarWalletsKit } from '@creit-tech/stellar-wallets-kit/sdk';
 import { defaultModules } from '@creit-tech/stellar-wallets-kit/modules/utils';
+import { StellarWalletsKit } from '@creit-tech/stellar-wallets-kit/sdk';
 import { Networks } from '@stellar/stellar-sdk';
 
 // Initialize flag to prevent multiple initializations

--- a/apps/web/providers/auth-provider.tsx
+++ b/apps/web/providers/auth-provider.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useRouter } from 'next/navigation';
 import {
   createContext,
   useCallback,
@@ -7,7 +8,6 @@ import {
   useEffect,
   useState,
 } from 'react';
-import { useRouter } from 'next/navigation';
 import { AuthService } from '@/lib/services/auth';
 import { supabase } from '@/lib/supabase';
 import type { User } from '@/lib/types';

--- a/apps/web/providers/trade-notifications.provider.tsx
+++ b/apps/web/providers/trade-notifications.provider.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { useEffect } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
+import { useEffect } from 'react';
 import { sileo } from 'sileo';
-import { supabase } from '@/lib/supabase';
 import { useAuth } from '@/hooks/use-auth';
+import { supabase } from '@/lib/supabase';
 
 // Matches actual trades.status values written to Supabase.
 // On-chain TrustlessWork states (funded, paymentReported, etc.) are not

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -1,5 +1,5 @@
 import { createServerClient } from '@supabase/ssr';
-import { NextResponse, type NextRequest } from 'next/server';
+import { type NextRequest, NextResponse } from 'next/server';
 
 export async function proxy(request: NextRequest) {
   let response = NextResponse.next({ request });


### PR DESCRIPTION
Part 1 of 2 of the plan agreed in #155 to stop `biome check` being red: **global formatting + safe lint fixes**. (Part 2 = a CI workflow running `biome ci --changed`, in a separate PR: #158.)

## What it does

1. **Global formatting of `apps/web`** via `biome check --write` (~98 files): applies the repo formatter (2-space, single quotes, lineWidth 80) + `organizeImports` + safe autofixes. **Formatting/imports only — no logic changes.**
2. **Mechanically-safe lint fixes** (the same safe subset, now folded in here):
   - 4x `as any` -> typed casts (`AuditAction`/`AuditTargetType`) in `audit-logs/route.ts`
   - `noImplicitAnyLet` -> `let data: unknown` in `merchants/[id]/route.ts`
   - `type="button"` x2 in `audit-log-viewer.tsx`
   - 2x redundant `role="listitem"` in `logo-loop.tsx`
   - `<title>` on the decorative svg in `macbook-scroll.tsx`

## Notes

- **Supersedes #156** (which had only the safe subset). #156 has been closed.
- This PR does **not** touch the remaining **behavioral/a11y** rules (`useHookAtTopLevel`, `useExhaustiveDependencies`, `noArrayIndexKey`, `useSemanticElements`, `noImgElement`, etc.) — they stay as visible debt; the CI gate (#158) enforces them only on files a PR actually modifies, without blocking on debt in untouched files.
- Best **merged isolated and soon** to minimize conflicts with in-flight branches (large formatting diff).

## Test plan

- [x] `npm run type-check` -> 9/9.
- [x] `npm run build` -> 6/6 OK.
- [x] Diff = formatting + the 6 safe fixes; no behavior changes.
