### PR TITLE
ci: gate PRs with Biome on changed files (#155)

### DIFF
--- a/.github/workflows/biome.yml
+++ b/.github/workflows/biome.yml
@@ -1,0 +1,38 @@
+name: Biome
+
+# Gate only the files changed in each PR (not the whole repo). Pre-existing
+# lint/format debt in untouched files does not block; new or modified code in
+# apps/web must be clean (format + lint).
+on:
+  pull_request:
+    paths:
+      - 'apps/web/**'
+      - '.github/workflows/biome.yml'
+
+jobs:
+  biome:
+    name: Lint changed files (apps/web)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Full history so Biome can diff against the PR base commit.
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Biome (changed files only)
+        working-directory: apps/web
+        run: >-
+          npx --no-install @biomejs/biome ci
+          --changed
+          --since=${{ github.event.pull_request.base.sha }}
+          .

--- a/.github/workflows/biome.yml
+++ b/.github/workflows/biome.yml
@@ -35,4 +35,5 @@ jobs:
           npx --no-install @biomejs/biome ci
           --changed
           --since=${{ github.event.pull_request.base.sha }}
+          --no-errors-on-unmatched
           .


### PR DESCRIPTION
Part 2 of 2 of #155: adds the repo's **first CI workflow** so Biome no longer depends on the global command (which carries pre-existing debt).

closes #155 

## What it does

`.github/workflows/biome.yml` runs on every PR that touches `apps/web/**`:
- `biome ci --changed --since=<base sha> --no-errors-on-unmatched .` (from `apps/web`) -> checks **only the files changed** in the PR.
- New/modified code must be **clean** (format + lint); pre-existing debt in untouched files does **not** block.

## Why `--changed` instead of `biome check .`

The global command has ~37 pre-existing behavioral/a11y errors + the repo was not formatted (fixed by #157). Gating only the diff lets us adopt the standard without a massive, risky sweep, and avoids blocking PRs over debt they do not touch.

## Merge order

Ideally **after #157** (global formatting), so already-formatted files do not trip the gate when touched. It also works standalone: it only requires cleanliness of what each PR changes.

## Notes

- First GitHub Actions workflow in the repo; Node 22 + `npm ci` (workspaces).
- `--no-errors-on-unmatched` is needed so a PR that changes no `apps/web` files (e.g. this one) does not fail Biome's "no files processed" error.
- Verified: the workflow run on this PR is **green**.
